### PR TITLE
[WIP] Expose and implement methods to update the global state of the network

### DIFF
--- a/crates/cli/src/commands/wallet/mod.rs
+++ b/crates/cli/src/commands/wallet/mod.rs
@@ -39,7 +39,7 @@ pub enum WalletCmd {
         from: AddressAlias,
 
         #[clap(long)]
-        to: String,
+        to: Address,
 
         #[clap(long)]
         amount: u128,

--- a/crates/cli/src/commands/wallet/transfer.rs
+++ b/crates/cli/src/commands/wallet/transfer.rs
@@ -1,3 +1,4 @@
+use primitives::Address;
 use vrrb_core::txn::Token;
 use vrrb_rpc::rpc::api::RpcTransactionDigest;
 use wallet::v2::Wallet;
@@ -7,7 +8,7 @@ use crate::result::CliError;
 pub async fn exec(
     wallet: &mut Wallet,
     address_number: u32,
-    to: String,
+    to: Address,
     amount: u128,
     token: Token,
 ) -> Result<RpcTransactionDigest, CliError> {

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use block::{Block, Conflict};
+use block::{Block, BlockHash, Conflict};
 use ethereum_types::U256;
 use primitives::{
     Address,
@@ -112,6 +112,7 @@ pub enum Event {
     FarmerQuorum(QuorumSize, FarmerQuorumThreshold),
     HarvesterQuorum(QuorumSize, HarvesterQuorumThreshold),
     CertifiedTxn(JobResult),
+    UpdateState(BlockHash),
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -4,7 +4,7 @@ pub use crate::miner::*;
 pub mod block_builder;
 pub mod conflict_resolver;
 pub mod miner_impl;
-pub(crate) mod test_helpers;
+pub mod test_helpers;
 // mod miner_v1;
 
 /// Legacy miner implementation

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -378,7 +378,7 @@ pub fn build_multiple_rounds(
                     epoch as u128,
                 );
 
-                append_proposal_blocks_to_dag(dag.clone(), proposals);
+                append_proposal_blocks_to_dag(&mut dag.clone(), proposals);
                 build_multiple_rounds(
                     dag.clone(),
                     n_blocks,
@@ -390,7 +390,7 @@ pub fn build_multiple_rounds(
                 );
             };
         } else {
-            if let Some(hash) = add_genesis_to_dag(dag.clone()) {
+            if let Some(hash) = add_genesis_to_dag(&mut dag.clone()) {
                 *round += 1usize;
                 build_multiple_rounds(
                     dag.clone(),
@@ -414,7 +414,7 @@ pub fn dag_has_genesis(dag: MinerDag) -> bool {
 
 /// build and adds a `GenesisBlock` to the `MinerDag`
 /// returns the `Some(hash)` if successful otherwise returns None
-pub fn add_genesis_to_dag(dag: MinerDag) -> Option<String> {
+pub fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
     let mut prop_vertices = Vec::new();
     let genesis = mine_genesis();
     let keypair = Keypair::random();
@@ -487,7 +487,7 @@ pub fn mine_next_convergence_block(dag: MinerDag) -> Option<String> {
 }
 
 /// Appends `ProposalBlock`s to the `MinerDag`
-pub fn append_proposal_blocks_to_dag(dag: MinerDag, proposals: Vec<ProposalBlock>) {
+pub fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
     let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
     for block in proposals.iter() {
         let ref_hash = block.ref_block.clone();

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -138,14 +138,15 @@ pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, 
     (0..n)
         .map(|n| {
             let (sk, pk) = create_keypair();
-            let raddr = "0x192abcdef01234567890".to_string();
+            let (rsk, rpk) = create_keypair();
             let saddr = create_address(&pk);
+            let raddr = create_address(&rpk);
             let amount = (n.pow(2)) as u128;
             let token = None;
 
             let txn_args = NewTxnArgs {
                 timestamp: 0,
-                sender_address: saddr.to_string(),
+                sender_address: saddr,
                 sender_public_key: pk.clone(),
                 receiver_address: raddr,
                 token,
@@ -163,9 +164,9 @@ pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, 
 
             let txn_digest_vec = generate_txn_digest_vec(
                 txn.timestamp,
-                txn.sender_address.clone(),
+                txn.sender_address.to_string(),
                 txn.sender_public_key.clone(),
-                txn.receiver_address.clone(),
+                txn.receiver_address.to_string(),
                 txn.token.clone(),
                 txn.amount,
                 txn.nonce,
@@ -247,7 +248,7 @@ pub(crate) fn mine_convergence_block_epoch_change() -> Result<Block, MinerError>
 /// A helper function that creates a `Miner` and returns both the
 /// `Miner` and the `MinerDag`
 pub(crate) fn create_miner_return_dag() -> (Miner, MinerDag) {
-    let mut miner = create_miner();
+    let miner = create_miner();
     let dag = miner.dag.clone();
 
     (miner, dag)

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -33,7 +33,7 @@ use crate::{result::MinerError, Miner, MinerConfig};
 pub type MinerDag = Arc<RwLock<BullDag<Block, String>>>;
 
 /// Helper function to create a random Miner.
-pub(crate) fn create_miner() -> Miner {
+pub fn create_miner() -> Miner {
     let (secret_key, public_key) = create_keypair();
     let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
     let ip_address = "127.0.0.1:8080".parse().unwrap();
@@ -47,7 +47,7 @@ pub(crate) fn create_miner() -> Miner {
 }
 
 /// Helper function to create a miner from a `Keypair`
-pub(crate) fn create_miner_from_keypair(kp: &Keypair) -> Miner {
+pub fn create_miner_from_keypair(kp: &Keypair) -> Miner {
     let (secret_key, public_key) = kp.miner_kp;
     let dag: MinerDag = Arc::new(RwLock::new(BullDag::new()));
     let ip_address = "127.0.0.1:8080".parse().unwrap();
@@ -60,12 +60,12 @@ pub(crate) fn create_miner_from_keypair(kp: &Keypair) -> Miner {
     Miner::new(config).unwrap()
 }
 
-pub(crate) fn create_miner_from_keypair_return_dag(kp: &Keypair) -> (Miner, MinerDag) {
+pub fn create_miner_from_keypair_return_dag(kp: &Keypair) -> (Miner, MinerDag) {
     let miner = create_miner_from_keypair(kp);
     (miner.clone(), miner.dag.clone())
 }
 
-pub(crate) fn create_miner_from_keypair_and_dag(kp: &Keypair, dag: MinerDag) -> Miner {
+pub fn create_miner_from_keypair_and_dag(kp: &Keypair, dag: MinerDag) -> Miner {
     let mut miner = create_miner_from_keypair(kp);
     miner.dag = dag;
     miner
@@ -73,19 +73,19 @@ pub(crate) fn create_miner_from_keypair_and_dag(kp: &Keypair, dag: MinerDag) -> 
 
 /// Helper function to create a `MinerKeypair` which is
 /// simply `(SecretKey, PublicKey)`
-pub(crate) fn create_keypair() -> (SecretKey, PublicKey) {
+pub fn create_keypair() -> (SecretKey, PublicKey) {
     let kp = Keypair::random();
     kp.miner_kp
 }
 
 /// Helper function to create an address from a `&PublicKey`
-pub(crate) fn create_address(public_key: &PublicKey) -> Address {
+pub fn create_address(public_key: &PublicKey) -> Address {
     Address::new(public_key.clone())
 }
 
 /// Helper function to create a claim from a `&PublicKey` and `&Address` and
 /// `ip_address` and `signature`
-pub(crate) fn create_claim(
+pub fn create_claim(
     pk: &PublicKey,
     addr: &Address,
     ip_address: SocketAddr,
@@ -96,7 +96,7 @@ pub(crate) fn create_claim(
 
 /// Helper function to create a random message and signature
 /// returning `(Message, Keypair, Signature)`
-pub(crate) fn create_and_sign_message() -> (Message, Keypair, Signature) {
+pub fn create_and_sign_message() -> (Message, Keypair, Signature) {
     let kp = Keypair::random();
     let message = b"Test Message";
     let msg = {
@@ -116,7 +116,7 @@ pub(crate) fn create_and_sign_message() -> (Message, Keypair, Signature) {
 /// This is currently using a deprecated method
 /// `miner.mine_genesis_block` will be removed soon
 /// and replaced by a different method.
-pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
+pub fn mine_genesis() -> Option<GenesisBlock> {
     let miner = create_miner();
 
     let claim = miner.generate_claim().unwrap();
@@ -134,7 +134,7 @@ pub(crate) fn mine_genesis() -> Option<GenesisBlock> {
 /// Helper function to create `n` number of `Txn` and
 /// return an `Iterator` of `(TransactionDigest, Txn)`
 /// to be collected by the caller.
-pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
+pub fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, Txn)> {
     (0..n)
         .map(|n| {
             let (sk, pk) = create_keypair();
@@ -182,7 +182,7 @@ pub(crate) fn create_txns(n: usize) -> impl Iterator<Item = (TransactionDigest, 
 /// Helper function to create `n` number of `Claim`s and
 /// return an `Iterator` of `(String, Claim)` to be collected
 /// by the caller
-pub(crate) fn create_claims(n: usize) -> impl Iterator<Item = (U256, Claim)> {
+pub fn create_claims(n: usize) -> impl Iterator<Item = (U256, Claim)> {
     (0..n)
         .map(|_| {
             let (sk, pk) = create_keypair();
@@ -203,7 +203,7 @@ pub(crate) fn create_claims(n: usize) -> impl Iterator<Item = (U256, Claim)> {
 /// A helper function to build a `ProposalBlock`. This function has been
 /// deprecated and replaced by the `build_single_proposal_block` function
 #[deprecated(note = "use `build_single_proposal_block` function instead")]
-pub(crate) fn build_proposal_block(
+pub fn build_proposal_block(
     ref_hash: &String,
     n_tx: usize,
     n_claims: usize,
@@ -231,7 +231,7 @@ pub(crate) fn build_proposal_block(
 
 /// A helper function to attempt to mine a `ConvergenceBlock`
 /// with a random `miner`
-pub(crate) fn mine_convergence_block() -> Result<Block, MinerError> {
+pub fn mine_convergence_block() -> Result<Block, MinerError> {
     let mut miner = create_miner();
     miner.try_mine()
 }
@@ -239,7 +239,7 @@ pub(crate) fn mine_convergence_block() -> Result<Block, MinerError> {
 /// A helper function to attempt to mine a `ConvergenceBlock`
 /// that signals a change in `Epoch` i.e. a block
 /// with a `round % Epoch == 0`
-pub(crate) fn mine_convergence_block_epoch_change() -> Result<Block, MinerError> {
+pub fn mine_convergence_block_epoch_change() -> Result<Block, MinerError> {
     let mut miner = create_miner();
     //TODO: Add Mock Convergence Block with round height of 29.999999mm
     miner.try_mine()
@@ -247,7 +247,7 @@ pub(crate) fn mine_convergence_block_epoch_change() -> Result<Block, MinerError>
 
 /// A helper function that creates a `Miner` and returns both the
 /// `Miner` and the `MinerDag`
-pub(crate) fn create_miner_return_dag() -> (Miner, MinerDag) {
+pub fn create_miner_return_dag() -> (Miner, MinerDag) {
     let miner = create_miner();
     let dag = miner.dag.clone();
 
@@ -257,7 +257,7 @@ pub(crate) fn create_miner_return_dag() -> (Miner, MinerDag) {
 /// A helper function that creates a random `Miner` and provides
 /// an existing `MinerDag` to replace the default one in the
 /// `Miner`. Returns both the `Miner` and the `MinerDag`
-pub(crate) fn create_miner_from_dag(dag: &MinerDag) -> (Miner, MinerDag) {
+pub fn create_miner_from_dag(dag: &MinerDag) -> (Miner, MinerDag) {
     let mut miner = create_miner();
     miner.dag = dag.clone();
 
@@ -265,7 +265,7 @@ pub(crate) fn create_miner_from_dag(dag: &MinerDag) -> (Miner, MinerDag) {
 }
 
 /// A helper function to build a single `ProposalBlock` and return it.
-pub(crate) fn build_single_proposal_block(
+pub fn build_single_proposal_block(
     last_block_hash: String,
     n_txns: usize,
     n_claims: usize,
@@ -281,7 +281,7 @@ pub(crate) fn build_single_proposal_block(
 
 /// A helper function to build `n` number of porposal blocks
 /// from random `Claim`s and return a `Vec<ProposalBlock>`
-pub(crate) fn build_multiple_proposal_blocks_single_round(
+pub fn build_multiple_proposal_blocks_single_round(
     n_blocks: usize,
     last_block_hash: String,
     n_txns: usize,
@@ -358,7 +358,7 @@ pub(crate) fn build_multiple_proposal_blocks_single_round(
 ///             Recursively calls itself passing in the GenesisBlock hash
 ///             as the last_block_hash and the updated round as the
 ///             round, as well as all the other data.
-pub(crate) fn build_multiple_rounds(
+pub fn build_multiple_rounds(
     dag: &mut MinerDag,
     n_blocks: usize,
     n_txns: usize,
@@ -410,13 +410,13 @@ pub(crate) fn build_multiple_rounds(
 
 /// Checks whether the DAG already has a root vertex
 /// returns true if so, false if not
-pub(crate) fn dag_has_genesis(dag: &mut MinerDag) -> bool {
+pub fn dag_has_genesis(dag: &mut MinerDag) -> bool {
     dag.read().unwrap().len() > 0
 }
 
 /// build and adds a `GenesisBlock` to the `MinerDag`
 /// returns the `Some(hash)` if successful otherwise returns None
-pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
+pub fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
     let mut prop_vertices = Vec::new();
     let genesis = mine_genesis();
     let keypair = Keypair::random();
@@ -452,7 +452,7 @@ pub(crate) fn add_genesis_to_dag(dag: &mut MinerDag) -> Option<String> {
 
 /// Mines the next `ConvergenceBlock` in the `MinerDag`
 /// Returns `Some(hash)` if successful otherwise returns `None`
-pub(crate) fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> {
+pub fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> {
     let keypair = Keypair::random();
     let mut miner = create_miner_from_keypair(&keypair);
     miner.dag = dag.clone();
@@ -489,7 +489,7 @@ pub(crate) fn mine_next_convergence_block(dag: &mut MinerDag) -> Option<String> 
 }
 
 /// Appends `ProposalBlock`s to the `MinerDag`
-pub(crate) fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
+pub fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<ProposalBlock>) {
     let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
     for block in proposals.iter() {
         let ref_hash = block.ref_block.clone();
@@ -517,7 +517,7 @@ pub(crate) fn append_proposal_blocks_to_dag(dag: &mut MinerDag, proposals: Vec<P
 
 /// Builds 2 `ProposalBlock`s which contain 5 of the same `Txn`s
 /// this is used to test conflict resolution mechanism of the `Miner`
-pub(crate) fn build_conflicting_proposal_blocks(
+pub fn build_conflicting_proposal_blocks(
     last_block_hash: String,
     round: u128,
     epoch: u128,
@@ -533,7 +533,7 @@ pub(crate) fn build_conflicting_proposal_blocks(
 
 /// Builds a single `ProposalBlock` and extends the `TxnList` of the
 /// `ProposalBlock` with transactions provided in the function call.
-pub(crate) fn build_single_proposal_block_from_txns(
+pub fn build_single_proposal_block_from_txns(
     last_block_hash: String,
     txns: impl IntoIterator<Item = (TransactionDigest, Txn)>,
     round: u128,
@@ -556,7 +556,7 @@ pub(crate) fn build_single_proposal_block_from_txns(
     prop
 }
 
-pub(crate) fn get_genesis_block_from_dag(dag: &mut MinerDag) -> Option<GenesisBlock> {
+pub fn get_genesis_block_from_dag(dag: &mut MinerDag) -> Option<GenesisBlock> {
     let last_block = {
         if let Ok(guard) = dag.read() {
             let root = guard.get_roots();
@@ -585,7 +585,7 @@ pub(crate) fn get_genesis_block_from_dag(dag: &mut MinerDag) -> Option<GenesisBl
     return last_block;
 }
 
-pub(crate) fn add_orphaned_block_to_dag(
+pub fn add_orphaned_block_to_dag(
     dag: &mut MinerDag,
     last_block_hash: String,
     txns: impl IntoIterator<Item = (TransactionDigest, Txn)>,

--- a/crates/node/src/runtime/farmer_module.rs
+++ b/crates/node/src/runtime/farmer_module.rs
@@ -347,6 +347,7 @@ mod tests {
             async_jobs_sender,
         );
         let keypair = KeyPair::random();
+        let recv_kp = KeyPair::random();
         let mut txns = HashSet::<Txn>::new();
 
         let now = SystemTime::now()
@@ -355,8 +356,8 @@ mod tests {
             .as_nanos();
 
         // let txn_id = String::from("1");
-        let sender_address = String::from("aaa1");
-        let receiver_address = String::from("bbb1");
+        let sender_address = Address::new(keypair.get_miner_public_key().clone());
+        let receiver_address = Address::new(recv_kp.get_miner_public_key().clone());
         let txn_amount: u128 = 1010101;
 
         for n in 1..101 {
@@ -369,7 +370,7 @@ mod tests {
 
             let txn = Txn::new(NewTxnArgs {
                 timestamp: 0,
-                sender_address: String::from("aaa1"),
+                sender_address: sender_address.clone(),
                 sender_public_key: keypair.get_miner_public_key().clone(),
                 receiver_address: receiver_address.clone(),
                 token: None,

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -126,6 +126,7 @@ pub async fn setup_runtime_components(
     let indexer_events_rx = router.subscribe(None)?;
     let dag_events_rx = router.subscribe(None)?;
 
+    let dag: Arc<RwLock<BullDag<Block, String>>> = Arc::new(RwLock::new(BullDag::new()));
     let mempool = LeftRightMempool::new();
     let mempool_read_handle_factory = mempool.factory();
 
@@ -149,6 +150,7 @@ pub async fn setup_runtime_components(
         &config,
         events_tx.clone(),
         vrrbdb_events_rx,
+        dag.clone(),
         mempool_read_handle_factory.clone(),
     )
     .await?;
@@ -205,8 +207,6 @@ pub async fn setup_runtime_components(
     config.jsonrpc_server_address = resolved_jsonrpc_server_addr;
 
     info!("JSON-RPC server address: {}", config.jsonrpc_server_address);
-
-    let dag: Arc<RwLock<BullDag<Block, String>>> = Arc::new(RwLock::new(BullDag::new()));
 
     let miner_handle = setup_mining_module(
         &config,
@@ -386,6 +386,7 @@ async fn setup_state_store(
     config: &NodeConfig,
     events_tx: EventPublisher,
     mut state_events_rx: EventSubscriber,
+    dag: Arc<RwLock<BullDag<Block, String>>>,
     _mempool_read_handle_factory: MempoolReadHandleFactory,
 ) -> Result<(VrrbDbReadHandle, Option<JoinHandle<Result<()>>>)> {
     let mut vrrbdb_config = VrrbDbConfig::default();
@@ -398,7 +399,7 @@ async fn setup_state_store(
 
     let vrrbdb_read_handle = db.read_handle();
 
-    let state_module = StateModule::new(state_module::StateModuleConfig { events_tx, db });
+    let state_module = StateModule::new(state_module::StateModuleConfig { events_tx, db, dag });
 
     let mut state_module_actor = ActorImpl::new(state_module);
 

--- a/crates/node/src/runtime/state_module.rs
+++ b/crates/node/src/runtime/state_module.rs
@@ -101,19 +101,22 @@ impl StateModule {
         update_list
             .into_iter()
             .for_each(|update| match &update.update_account {
+                //TODO: Put Address in UpdateArgs and just pass UpdateArgs
                 UpdateAccount::Sender => {
                     if let Some(args) = self.get_sender_update_args(update) {
-                        self.db.update_account(update.address.clone(), args);
+                        self.db.update_account(args);
                     }
                 },
                 UpdateAccount::Receiver => {
                     if let Some(args) = self.get_receiver_update_args(update) {
-                        self.db.update_account(update.address.clone(), args);
+                        self.db.update_account(args);
                     }
                 },
                 UpdateAccount::Claim => {
                     if let Some(args) = self.get_claim_update_args(update) {
-                        self.db.update_account(update.address.clone(), args);
+                        // TODO: provide an `update_claim` method in VrrbDb
+                        // to access the `ClaimStore` and update claims
+                        self.db.update_account(args);
                     }
                 },
             });
@@ -152,6 +155,7 @@ impl StateModule {
             digests.insert(nonce, update.digest.clone());
 
             return Some(UpdateArgs {
+                address: update.address,
                 nonce,
                 credits: None,
                 debits: Some(debits),
@@ -181,6 +185,7 @@ impl StateModule {
             digests.insert(nonce, update.digest.clone());
 
             return Some(UpdateArgs {
+                address: update.address,
                 nonce,
                 credits: None,
                 debits: Some(debits),
@@ -258,10 +263,12 @@ impl Handler<EventMessage> for StateModule {
                 }
             },
             Event::AccountUpdateRequested((address, account_bytes)) => {
-                if let Ok(account) = decode_from_binary_byte_slice(&account_bytes) {
-                    self.update_account(address, account)
-                        .map_err(|err| TheaterError::Other(err.to_string()))?;
-                }
+                //                if let Ok(account) =
+                // decode_from_binary_byte_slice(&account_bytes) {
+                // self.update_account(address, account)
+                // .map_err(|err| TheaterError::Other(err.to_string()))?;
+                //               }
+                todo!()
             },
             Event::NoOp => {},
             _ => {},

--- a/crates/node/src/runtime/state_module.rs
+++ b/crates/node/src/runtime/state_module.rs
@@ -333,7 +333,7 @@ impl StateModule {
     /// updates the StateStore, ClaimStore and TransactionStore
     /// for all new claims and transactions (excluding
     /// ClaimStaking transactions currently).
-    fn update_state(&mut self, block_hash: BlockHash) -> Result<()> {
+    pub fn update_state(&mut self, block_hash: BlockHash) -> Result<()> {
         if let Some(mut round_blocks) = self.get_proposal_blocks(block_hash) {
             consolidate_update_args(get_update_args(self.get_update_list(&mut round_blocks)))
                 .into_iter()

--- a/crates/node/src/runtime/state_module.rs
+++ b/crates/node/src/runtime/state_module.rs
@@ -39,6 +39,7 @@ pub enum UpdateAccount {
     Sender,
     Receiver,
     Claim,
+    Fee,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -98,6 +99,15 @@ impl From<StateUpdate> for UpdateArgs {
                 storage: None,
                 code: None,
                 digests: None,
+            },
+            UpdateAccount::Fee => UpdateArgs {
+                address: item.address,
+                nonce: item.nonce,
+                credits: Some(item.amount),
+                debits: None,
+                storage: None,
+                code: None,
+                digests: Some(digests.clone()),
             },
         }
     }

--- a/crates/node/src/runtime/state_module.rs
+++ b/crates/node/src/runtime/state_module.rs
@@ -422,10 +422,17 @@ impl StateModule {
 
     /// Inserts an account into the `VrrbDb` `StateStore`. This method Should
     /// only be used for *new* accounts
-    fn insert_account(&mut self, key: Address, account: Account) -> Result<()> {
+    pub fn insert_account(&mut self, key: Address, account: Account) -> Result<()> {
         self.db
             .insert_account(key, account)
             .map_err(|err| NodeError::Other(err.to_string()))
+    }
+
+    pub fn extend_accounts(&mut self, accounts: Vec<(Address, Account)>) -> Result<()> {
+        for (key, account) in accounts.into_iter() {
+            self.insert_account(key, account)?;
+        }
+        Ok(())
     }
 
     /// Returns a read handle for the StateStore to be able to read

--- a/crates/node/tests/block_processing.rs
+++ b/crates/node/tests/block_processing.rs
@@ -3,7 +3,7 @@ use node::{
     test_utils::{create_mock_bootstrap_node_config, create_mock_full_node_config_with_bootstrap},
     Node,
 };
-use primitives::generate_account_keypair;
+use primitives::{generate_account_keypair, Address};
 use secp256k1::Message;
 use telemetry::TelemetrySubscriber;
 use tokio::sync::mpsc::unbounded_channel;
@@ -32,6 +32,7 @@ async fn process_full_node_event_flow() {
 
     for _ in 0..1_00 {
         let (sk, pk) = generate_account_keypair();
+        let (_, recv_pk) = generate_account_keypair();
 
         let signature =
             sk.sign_ecdsa(Message::from_hashed_data::<secp256k1::hashes::sha256::Hash>(b"vrrb"));
@@ -39,9 +40,9 @@ async fn process_full_node_event_flow() {
         client
             .create_txn(NewTxnArgs {
                 timestamp: 0,
-                sender_address: String::from("mock sender_address"),
-                sender_public_key: pk,
-                receiver_address: String::from("mock receiver_address"),
+                sender_address: Address::new(pk.clone()),
+                sender_public_key: pk.clone(),
+                receiver_address: Address::new(recv_pk.clone()),
                 token: None,
                 amount: 0,
                 signature,

--- a/crates/node/tests/state_sync.rs
+++ b/crates/node/tests/state_sync.rs
@@ -6,7 +6,7 @@ use std::{
 use events::Event;
 use jsonrpsee::{core::client::Subscription, ws_client::WsClientBuilder};
 use node::{test_utils::create_mock_full_node_config, Node, NodeType, RuntimeModuleState};
-use primitives::generate_account_keypair;
+use primitives::{generate_account_keypair, Address};
 use secp256k1::Message;
 use tokio::sync::mpsc::unbounded_channel;
 use vrrb_config::NodeConfig;
@@ -48,15 +48,16 @@ async fn nodes_can_synchronize_state() {
 
     for _ in 0..1_00 {
         let (sk, pk) = generate_account_keypair();
+        let (_, recv_pk) = generate_account_keypair();
 
         let signature =
             sk.sign_ecdsa(Message::from_hashed_data::<secp256k1::hashes::sha256::Hash>(b"vrrb"));
         client_1
             .create_txn(NewTxnArgs {
                 timestamp: 0,
-                sender_address: String::from("mock sender_address"),
-                sender_public_key: pk,
-                receiver_address: String::from("mock receiver_address"),
+                sender_address: Address::new(pk.clone()),
+                sender_public_key: pk.clone(),
+                receiver_address: Address::new(recv_pk.clone()),
                 token: None,
                 amount: 0,
                 signature,

--- a/crates/node/tests/state_writes.rs
+++ b/crates/node/tests/state_writes.rs
@@ -7,14 +7,7 @@ use std::{
 use block::{Block, BlockHash, GenesisBlock, ProposalBlock};
 use bulldag::{graph::BullDag, vertex::Vertex};
 use hbbft::crypto::SecretKeyShare;
-use miner::test_helpers::{
-    build_single_proposal_block,
-    create_claim,
-    create_claims,
-    create_keypair,
-    mine_genesis,
-    mine_next_convergence_block,
-};
+use miner::test_helpers::*;
 use node::state_module::{StateModule, StateModuleConfig};
 use primitives::{generate_account_keypair, Address};
 use secp256k1::Message;

--- a/crates/node/tests/state_writes.rs
+++ b/crates/node/tests/state_writes.rs
@@ -21,6 +21,7 @@ use vrrb_core::{
 };
 
 #[tokio::test]
+#[ignore]
 async fn vrrbdb_should_update_with_new_block() {
     let (accounts, block_hash, mut state_module) = produce_state_module(5, 5);
     let _ = state_module.update_state(block_hash);
@@ -103,7 +104,9 @@ fn produce_genesis_block() -> GenesisBlock {
     mine_genesis().unwrap()
 }
 
+
 fn produce_proposal_blocks(
+    last_block_hash: BlockHash,
     accounts: Vec<(Address, Account)>,
     n: usize,
     ntx: usize,

--- a/crates/node/tests/state_writes.rs
+++ b/crates/node/tests/state_writes.rs
@@ -9,26 +9,15 @@ use node::state_module::{StateModule, StateModuleConfig};
 use primitives::Address;
 use storage::vrrbdb::{VrrbDb, VrrbDbConfig};
 use tokio::sync::mpsc::channel;
-use vrrb_core::{account::Account, txn::Txn};
+use vrrb_core::{account::Account, claim::Claim, txn::Txn};
 
 #[tokio::test]
 async fn vrrbdb_should_update_with_new_block() {
-    // setup necessary components to conduct test,
-    // including VrrbDb instance & DAG instance.
-    // DAG instance should already have 1 round under its
-    // belt, i.e. a GenesisBlock, at least 1 ProposalBlock and
-    // at least 1 Convergence block.
-    // Provide the StateModule with the necessary configuration
-    // including a copy of the VrrbDb and the DAG
-    // Provide the BlockHash for the ConvergenceBlock and call the
-    // state_module.update_state(); method passing the ConvergenceBlock
-    // hash into it.
-    // Check the VrrbDb instance to ensure that the transactions and
-    // claims in the PropsalBlock(s)/ConvergenceBlock are reflected
-    // in the db, including in the StateStore, ClaimStore and
-    // TransactionStore
     let (block_hash, mut state_module) = produce_state_module(5, 5);
     let _ = state_module.update_state(block_hash);
+
+    // Check that transactions in the ProposalBlocks are reflected
+    // in the StateModule
 
     todo!();
 }
@@ -61,6 +50,10 @@ fn populate_db_with_accounts(db: &mut VrrbDb, n: usize) -> Vec<(Address, Account
     accounts
 }
 
+fn produce_random_claims(n: usize) -> HashSet<Claim> {
+    todo!()
+}
+
 fn produce_random_txs(n: usize, accounts: &Vec<(Address, Account)>) -> HashSet<Txn> {
     (0..n).into_iter().map(|_| Txn::null_txn()).collect()
 }
@@ -74,7 +67,14 @@ fn produce_proposal_blocks(
     n: usize,
     ntx: usize,
 ) -> Vec<ProposalBlock> {
-    let txs = produce_random_txs(ntx, &accounts);
+    let proposals: Vec<ProposalBlock> = (0..n)
+        .into_iter()
+        .map(|_| {
+            let txs = produce_random_txs(ntx, &accounts);
+            let claims = produce_random_claims(ntx);
+            todo!()
+        })
+        .collect();
     todo!()
 }
 

--- a/crates/node/tests/state_writes.rs
+++ b/crates/node/tests/state_writes.rs
@@ -1,3 +1,16 @@
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+};
+
+use block::{Block, BlockHash, ConvergenceBlock, GenesisBlock, ProposalBlock};
+use bulldag::{graph::BullDag, vertex::Vertex};
+use node::state_module::{StateModule, StateModuleConfig};
+use primitives::Address;
+use storage::vrrbdb::{VrrbDb, VrrbDbConfig};
+use tokio::sync::mpsc::channel;
+use vrrb_core::{account::Account, txn::Txn};
+
 #[tokio::test]
 async fn vrrbdb_should_update_with_new_block() {
     // setup necessary components to conduct test,
@@ -14,5 +27,98 @@ async fn vrrbdb_should_update_with_new_block() {
     // claims in the PropsalBlock(s)/ConvergenceBlock are reflected
     // in the db, including in the StateStore, ClaimStore and
     // TransactionStore
+    let (block_hash, mut state_module) = produce_state_module(5, 5);
+    let _ = state_module.update_state(block_hash);
+
     todo!();
+}
+
+
+fn produce_state_module(ntx: usize, npb: usize) -> (BlockHash, StateModule) {
+    let (events_tx, _) = channel(100);
+    let db_config = VrrbDbConfig::default();
+    let mut db = VrrbDb::new(db_config.clone());
+    let accounts = populate_db_with_accounts(&mut db, 10);
+    let (block_hash, dag) = build_dag(accounts, ntx, npb);
+    let dag = Arc::new(RwLock::new(dag.clone()));
+    let config = StateModuleConfig {
+        db: VrrbDb::new(db_config),
+        events_tx,
+        dag: dag.clone(),
+    };
+
+    (block_hash, StateModule::new(config))
+}
+
+fn produce_accounts(n: usize) -> Vec<(Address, Account)> {
+    todo!()
+}
+
+fn populate_db_with_accounts(db: &mut VrrbDb, n: usize) -> Vec<(Address, Account)> {
+    let accounts = produce_accounts(n);
+    db.extend_accounts(accounts.clone());
+
+    accounts
+}
+
+fn produce_random_txs(n: usize, accounts: &Vec<(Address, Account)>) -> HashSet<Txn> {
+    (0..n).into_iter().map(|_| Txn::null_txn()).collect()
+}
+
+fn produce_genesis_block() -> GenesisBlock {
+    todo!()
+}
+
+fn produce_proposal_blocks(
+    accounts: Vec<(Address, Account)>,
+    n: usize,
+    ntx: usize,
+) -> Vec<ProposalBlock> {
+    let txs = produce_random_txs(ntx, &accounts);
+    todo!()
+}
+
+fn produce_convergence_block(proposals: Vec<ProposalBlock>) -> ConvergenceBlock {
+    todo!()
+}
+
+fn build_dag(
+    accounts: Vec<(Address, Account)>,
+    ntx: usize,
+    npb: usize,
+) -> (BlockHash, BullDag<Block, BlockHash>) {
+    let mut dag = BullDag::new();
+
+    let genesis = produce_genesis_block();
+    let block: Block = genesis.into();
+    let genesis_vtx: Vertex<Block, BlockHash> = block.into();
+    dag.add_vertex(&genesis_vtx);
+    let proposals = produce_proposal_blocks(accounts, npb, ntx);
+    let proposal_vtxs: Vec<Vertex<Block, BlockHash>> = {
+        proposals
+            .iter()
+            .map(|pblock| {
+                let block: Block = pblock.clone().into();
+                let vtx: Vertex<Block, BlockHash> = block.into();
+                vtx
+            })
+            .collect()
+    };
+
+    let edges = proposal_vtxs
+        .iter()
+        .map(|pvtx| (&genesis_vtx, pvtx))
+        .collect();
+
+    dag.extend_from_edges(edges);
+
+    let convergence = produce_convergence_block(proposals);
+    let c_block: Block = convergence.clone().into();
+    let cvtx: Vertex<Block, BlockHash> = c_block.into();
+
+    let c_edges = proposal_vtxs.iter().map(|pvtx| (pvtx, &cvtx)).collect();
+
+    dag.extend_from_edges(c_edges);
+
+    (convergence.hash, dag)
 }

--- a/crates/node/tests/state_writes.rs
+++ b/crates/node/tests/state_writes.rs
@@ -1,16 +1,17 @@
+#![cfg(test)]
+
 use std::{
     collections::HashSet,
     net::SocketAddr,
     sync::{Arc, RwLock},
 };
 
-use block::{Block, BlockHash, GenesisBlock, ProposalBlock};
+use block::{Block, BlockHash, GenesisBlock, InnerBlock, ProposalBlock};
 use bulldag::{graph::BullDag, vertex::Vertex};
 use hbbft::crypto::SecretKeyShare;
-use miner::test_helpers::*;
 use node::state_module::{StateModule, StateModuleConfig};
 use primitives::{generate_account_keypair, Address};
-use secp256k1::Message;
+use secp256k1::{Message, PublicKey, SecretKey};
 use storage::vrrbdb::{VrrbDb, VrrbDbConfig};
 use tokio::sync::mpsc::channel;
 use vrrb_core::{
@@ -20,44 +21,59 @@ use vrrb_core::{
     txn::{generate_txn_digest_vec, NewTxnArgs, TransactionDigest, Txn},
 };
 
+pub type StateDag = Arc<RwLock<BullDag<Block, BlockHash>>>;
+
 #[tokio::test]
-#[ignore]
 async fn vrrbdb_should_update_with_new_block() {
-    let (accounts, block_hash, mut state_module) = produce_state_module(5, 5);
-    let _ = state_module.update_state(block_hash);
-
-    let handle = state_module.read_handle();
-    let account_values = handle.state_store_values();
-    accounts.iter().for_each(|(address, _)| {
-        if let Some(account) = account_values.get(address) {
-            let digests = account.digests;
-            assert!(digests.len() > 0);
-            assert!(digests.get_sent().len() > 0);
-            assert!(digests.get_recv().len() > 0);
-        }
-    });
-
-    todo!();
-}
-
-
-fn produce_state_module(
-    ntx: usize,
-    npb: usize,
-) -> (Vec<(Address, Account)>, BlockHash, StateModule) {
-    let (events_tx, _) = channel(100);
+    println!("setting up state module");
     let db_config = VrrbDbConfig::default();
-    let mut db = VrrbDb::new(db_config.clone());
-    let accounts = populate_db_with_accounts(&mut db, 10);
-    let (block_hash, dag) = build_dag(accounts.clone(), ntx, npb);
-    let dag = dag.clone();
+    let db = VrrbDb::new(db_config.clone());
+    let accounts: Vec<(Address, Account)> = produce_accounts(5);
+    let dag: StateDag = Arc::new(RwLock::new(BullDag::new()));
+    let (events_tx, _) = channel(100);
     let config = StateModuleConfig {
-        db: VrrbDb::new(db_config),
+        db,
         events_tx,
         dag: dag.clone(),
     };
+    let mut state_module = StateModule::new(config);
+    let _ = state_module.extend_accounts(accounts.clone());
+    println!("mining genesis block");
+    let genesis = produce_genesis_block();
 
-    (accounts, block_hash, StateModule::new(config))
+    let gblock: Block = genesis.clone().into();
+    let gvtx: Vertex<Block, BlockHash> = gblock.into();
+    if let Ok(mut guard) = dag.write() {
+        println!("adding genesis block to dag");
+        guard.add_vertex(&gvtx);
+    }
+
+    println!("producing proposal blocks");
+    let proposals = produce_proposal_blocks(genesis.clone().hash, accounts, 5, 5);
+
+    println!("creating edges from proposal blocks");
+    let edges: Vec<(Vertex<Block, BlockHash>, Vertex<Block, BlockHash>)> = {
+        proposals
+            .into_iter()
+            .map(|pblock| {
+                let pblock: Block = pblock.clone().into();
+                let pvtx: Vertex<Block, BlockHash> = pblock.into();
+                (gvtx.clone(), pvtx.clone())
+            })
+            .collect()
+    };
+
+    if let Ok(mut guard) = dag.write() {
+        println!("adding edgest to dag");
+        edges
+            .iter()
+            .for_each(|(source, reference)| guard.add_edge((&source, &reference)));
+    }
+
+    if let Some(block_hash) = produce_convergence_block(dag.clone()) {
+        println!("updating state from convergence block");
+        let _ = state_module.update_state(block_hash);
+    }
 }
 
 fn produce_accounts(n: usize) -> Vec<(Address, Account)> {
@@ -72,14 +88,29 @@ fn produce_accounts(n: usize) -> Vec<(Address, Account)> {
         .collect()
 }
 
-fn populate_db_with_accounts(db: &mut VrrbDb, n: usize) -> Vec<(Address, Account)> {
-    let accounts = produce_accounts(n);
-    db.extend_accounts(accounts.clone());
-    accounts
-}
-
 fn produce_random_claims(n: usize) -> HashSet<Claim> {
-    create_claims(n).into_iter().collect()
+    (0..n)
+        .into_iter()
+        .map(|_| {
+            let kp = Keypair::random();
+            let address = Address::new(kp.miner_kp.1.clone());
+            let ip_address = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
+            let signature = Claim::signature_for_valid_claim(
+                kp.miner_kp.1.clone(),
+                ip_address.clone(),
+                kp.get_miner_secret_key().secret_bytes().to_vec(),
+            )
+            .unwrap();
+
+            Claim::new(
+                kp.miner_kp.1.clone(),
+                address.clone(),
+                ip_address,
+                signature,
+            )
+            .unwrap()
+        })
+        .collect()
 }
 
 fn produce_random_txs(accounts: &Vec<(Address, Account)>) -> HashSet<Txn> {
@@ -88,20 +119,32 @@ fn produce_random_txs(accounts: &Vec<(Address, Account)>) -> HashSet<Txn> {
         .iter()
         .enumerate()
         .map(|(idx, (address, account))| {
-            let sender = accounts[idx];
             let receiver: (Address, Account);
             if (idx + 1) == accounts.len() {
-                let receiver = accounts[0];
+                receiver = accounts[0].clone();
             } else {
-                let receiver = accounts[idx + 1];
+                receiver = accounts[idx + 1].clone();
             }
-            create_txn_from_accounts(sender, receiver.0)
+
+            let mut validators: Vec<(String, bool)> = vec![];
+
+            accounts.clone().iter().for_each(|validator| {
+                if (validator.clone() != receiver)
+                    && (validator.clone() != (address.clone(), account.clone()))
+                {
+                    let pk = validator.clone().0.public_key().to_string();
+                    validators.push((pk, true));
+                }
+            });
+
+            create_txn_from_accounts((address.clone(), account.clone()), receiver.0, validators)
         })
         .collect()
 }
 
 fn produce_genesis_block() -> GenesisBlock {
-    mine_genesis().unwrap()
+    let genesis = miner::test_helpers::mine_genesis();
+    genesis.unwrap()
 }
 
 
@@ -110,7 +153,6 @@ fn produce_proposal_blocks(
     accounts: Vec<(Address, Account)>,
     n: usize,
     ntx: usize,
-    last_block_hash: BlockHash,
 ) -> Vec<ProposalBlock> {
     (0..n)
         .into_iter()
@@ -133,13 +175,13 @@ fn produce_proposal_blocks(
             .unwrap();
             let txs = produce_random_txs(&accounts);
             let claims = produce_random_claims(ntx);
-            let txn_list = txs.into_iter().map(|tx| (tx.into(), tx)).collect();
+            let txn_list = txs.into_iter().map(|tx| (tx.clone().into(), tx)).collect();
             let claim_list = claims
                 .into_iter()
                 .map(|claim| (claim.hash, claim))
                 .collect();
             ProposalBlock::build(
-                last_block_hash,
+                last_block_hash.clone(),
                 0,
                 0,
                 txn_list,
@@ -151,54 +193,62 @@ fn produce_proposal_blocks(
         .collect()
 }
 
-fn produce_convergence_block(dag: &mut Arc<RwLock<BullDag<Block, BlockHash>>>) -> BlockHash {
-    mine_next_convergence_block(dag)
+fn produce_convergence_block(dag: Arc<RwLock<BullDag<Block, BlockHash>>>) -> Option<BlockHash> {
+    let keypair = Keypair::random();
+    let mut miner = miner::test_helpers::create_miner_from_keypair(&keypair);
+    miner.dag = dag.clone();
+    let last_block = miner::test_helpers::get_genesis_block_from_dag(dag.clone());
+
+    if let Some(block) = last_block {
+        miner.last_block = Some(Arc::new(block));
+    }
+
+    if let Ok(cblock) = miner.try_mine() {
+        if let Block::Convergence { ref block } = cblock.clone() {
+            let cvtx: Vertex<Block, String> = cblock.into();
+            let mut edges: Vec<(Vertex<Block, String>, Vertex<Block, String>)> = vec![];
+            if let Ok(guard) = dag.clone().read() {
+                block.clone().get_ref_hashes().iter().for_each(|t| {
+                    if let Some(pvtx) = guard.get_vertex(t.clone()) {
+                        edges.push((pvtx.clone(), cvtx.clone()));
+                    }
+                });
+            }
+
+            if let Ok(mut guard) = dag.clone().write() {
+                let edges = edges
+                    .iter()
+                    .map(|(source, reference)| (source, reference))
+                    .collect();
+                guard.extend_from_edges(edges);
+                return Some(block.get_hash());
+            }
+        }
+    }
+
+    None
 }
 
-fn build_dag(
-    accounts: Vec<(Address, Account)>,
-    ntx: usize,
-    npb: usize,
-) -> (BlockHash, Arc<RwLock<BullDag<Block, BlockHash>>>) {
-    let mut dag = BullDag::new();
-
-    let genesis = produce_genesis_block();
-    let block: Block = genesis.clone().into();
-    let genesis_vtx: Vertex<Block, BlockHash> = block.into();
-    dag.add_vertex(&genesis_vtx);
-    let proposals = produce_proposal_blocks(accounts, npb, ntx, genesis.hash.clone());
-    let proposal_vtxs: Vec<Vertex<Block, BlockHash>> = {
-        proposals
-            .iter()
-            .map(|pblock| {
-                let block: Block = pblock.clone().into();
-                let vtx: Vertex<Block, BlockHash> = block.into();
-                vtx
-            })
-            .collect()
-    };
-
-    let edges = proposal_vtxs
-        .iter()
-        .map(|pvtx| (&genesis_vtx, pvtx))
-        .collect();
-
-    dag.extend_from_edges(edges);
-
-    let mut dag = Arc::new(RwLock::new(dag));
-
-    let convergence = produce_convergence_block(&mut dag.clone());
-
-    (convergence, dag)
+pub fn create_keypair() -> (SecretKey, PublicKey) {
+    let kp = Keypair::random();
+    kp.miner_kp
 }
 
-pub(crate) fn create_txn_from_accounts(sender: (Address, Account), receiver: Address) -> Txn {
+pub(crate) fn create_txn_from_accounts(
+    sender: (Address, Account),
+    receiver: Address,
+    validators: Vec<(String, bool)>,
+) -> Txn {
     let (sk, pk) = create_keypair();
-    let (rsk, rpk) = create_keypair();
     let saddr = sender.0.clone();
     let raddr = receiver.clone();
     let amount = 100u128.pow(2);
     let token = None;
+
+    let mut validators = validators
+        .iter()
+        .map(|(k, v)| (k.to_string().clone(), v.clone()))
+        .collect();
 
     let txn_args = NewTxnArgs {
         timestamp: 0,
@@ -209,7 +259,7 @@ pub(crate) fn create_txn_from_accounts(sender: (Address, Account), receiver: Add
         amount,
         signature: sk
             .sign_ecdsa(Message::from_hashed_data::<secp256k1::hashes::sha256::Hash>(b"vrrb")),
-        validators: None,
+        validators: Some(validators),
         nonce: sender.1.nonce + 1,
     };
 
@@ -227,7 +277,7 @@ pub(crate) fn create_txn_from_accounts(sender: (Address, Account), receiver: Add
         txn.nonce,
     );
 
-    let digest = TransactionDigest::from(txn_digest_vec);
+    let _digest = TransactionDigest::from(txn_digest_vec);
 
     txn
 }

--- a/crates/node/tests/state_writes.rs
+++ b/crates/node/tests/state_writes.rs
@@ -1,0 +1,18 @@
+#[tokio::test]
+async fn vrrbdb_should_update_with_new_block() {
+    // setup necessary components to conduct test,
+    // including VrrbDb instance & DAG instance.
+    // DAG instance should already have 1 round under its
+    // belt, i.e. a GenesisBlock, at least 1 ProposalBlock and
+    // at least 1 Convergence block.
+    // Provide the StateModule with the necessary configuration
+    // including a copy of the VrrbDb and the DAG
+    // Provide the BlockHash for the ConvergenceBlock and call the
+    // state_module.update_state(); method passing the ConvergenceBlock
+    // hash into it.
+    // Check the VrrbDb instance to ensure that the transactions and
+    // claims in the PropsalBlock(s)/ConvergenceBlock are reflected
+    // in the db, including in the StateStore, ClaimStore and
+    // TransactionStore
+    todo!();
+}

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ByteVec, PublicKey, SecretKey};
 
 /// Represents a secp256k1 public key, hashed with sha256::digest
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct Address(PublicKey);
 
 impl Address {

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -10,3 +10,4 @@ vrrbdb = { workspace = true }
 lr_trie = { workspace = true }
 storage_utils = { workspace = true }
 serial_test = { workspace = true }
+ethereum-types = { workspace = true }

--- a/crates/storage/vrrbdb/Cargo.toml
+++ b/crates/storage/vrrbdb/Cargo.toml
@@ -20,6 +20,7 @@ rocksdb = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 telemetry = { workspace = true }
+ethereum-types = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/storage/vrrbdb/src/claim_store/mod.rs
+++ b/crates/storage/vrrbdb/src/claim_store/mod.rs
@@ -1,8 +1,8 @@
 use std::{path::PathBuf, sync::Arc};
 
+use ethereum_types::U256;
 use lr_trie::{LeftRightTrie, H256};
-use primitives::{NodeId, NodeIdentifier};
-use sha2::Digest;
+use primitives::NodeId;
 use storage_utils::{Result, StorageError};
 use vrrb_core::claim::Claim;
 
@@ -12,11 +12,11 @@ mod claim_store_rh;
 pub use claim_store_rh::*;
 
 pub type Claims = Vec<Claim>;
-pub type FailedClaimUpdates = Vec<(NodeId, Claims, Result<()>)>;
+pub type FailedClaimUpdates = Vec<(U256, Claims, Result<()>)>;
 
 #[derive(Debug, Clone)]
 pub struct ClaimStore {
-    trie: LeftRightTrie<'static, NodeId, Claim, RocksDbAdapter>,
+    trie: LeftRightTrie<'static, U256, Claim, RocksDbAdapter>,
 }
 
 impl Default for ClaimStore {
@@ -59,7 +59,7 @@ impl ClaimStore {
     }
 
     // Maybe initialize is better name for that?
-    fn insert_uncommited(&mut self, key: NodeIdentifier, claim: Claim) -> Result<()> {
+    fn insert_uncommited(&mut self, claim: Claim) -> Result<()> {
         //        if claim.debits != 0 {
         //            return Err(StorageError::Other(
         //                "cannot insert claim with debit".to_string(),
@@ -72,14 +72,14 @@ impl ClaimStore {
         //            ));
         //        }
 
-        self.trie.insert_uncommitted(key, claim);
+        self.trie.insert_uncommitted(claim.hash, claim);
 
         Ok(())
     }
 
     /// Inserts new claim into ClaimDb.
-    pub fn insert(&mut self, key: NodeId, claim: Claim) -> Result<()> {
-        self.insert_uncommited(key, claim)?;
+    pub fn insert(&mut self, claim: Claim) -> Result<()> {
+        self.insert_uncommited(claim)?;
         self.commit_changes();
         Ok(())
     }
@@ -90,13 +90,13 @@ impl ClaimStore {
     // inserted
     fn batch_insert_uncommited(
         &mut self,
-        inserts: Vec<(NodeId, Claim)>,
-    ) -> Option<Vec<(NodeId, Claim, StorageError)>> {
-        let mut failed_inserts: Vec<(NodeId, Claim, StorageError)> = vec![];
+        inserts: Vec<(U256, Claim)>,
+    ) -> Option<Vec<(U256, Claim, StorageError)>> {
+        let mut failed_inserts: Vec<(U256, Claim, StorageError)> = vec![];
 
         inserts.iter().for_each(|item| {
             let (k, v) = item;
-            if let Err(e) = self.insert_uncommited(k.to_owned(), v.clone()) {
+            if let Err(e) = self.insert_uncommited(v.clone()) {
                 failed_inserts.push((k.to_owned(), v.clone(), e));
             }
         });
@@ -115,8 +115,8 @@ impl ClaimStore {
     /// Otherwise returns vector of (key, claim_to_be_inserted, error).
     pub fn batch_insert(
         &mut self,
-        inserts: Vec<(NodeId, Claim)>,
-    ) -> Option<Vec<(NodeId, Claim, StorageError)>> {
+        inserts: Vec<(U256, Claim)>,
+    ) -> Option<Vec<(U256, Claim, StorageError)>> {
         let failed_inserts = self.batch_insert_uncommited(inserts);
         self.commit_changes();
         failed_inserts
@@ -271,7 +271,7 @@ impl ClaimStore {
         self.trie.root()
     }
 
-    pub fn extend(&mut self, claims: Vec<(NodeId, Claim)>) {
+    pub fn extend(&mut self, claims: Vec<(U256, Claim)>) {
         self.trie.extend(claims)
     }
 

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use lr_trie::{LeftRightTrie, H256};
 use primitives::Address;
-use sha2::Digest;
 use storage_utils::{Result, StorageError};
 use vrrb_core::account::{Account, UpdateArgs};
 

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -162,6 +162,8 @@ impl StateStore {
             .update(update)
             .map_err(|err| StorageError::Other(err.to_string()))?;
 
+        self.trie.update(key, account.clone());
+
         Ok(())
     }
 

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -168,7 +168,8 @@ impl StateStore {
     /// Updates an Account in the database under given PublicKey
     ///
     /// If succesful commits the change. Otherwise returns an error.
-    pub fn update(&mut self, key: Address, update: UpdateArgs) -> Result<()> {
+    pub fn update(&mut self, update: UpdateArgs) -> Result<()> {
+        let key = update.address.clone();
         self.update_uncommited(key, update)?;
         self.commit_changes();
         Ok(())

--- a/crates/storage/vrrbdb/src/state_store/mod.rs
+++ b/crates/storage/vrrbdb/src/state_store/mod.rs
@@ -52,6 +52,11 @@ impl StateStore {
         StateStoreReadHandle::new(inner)
     }
 
+    pub fn get_account(&self, key: &Address) -> Result<Account> {
+        let read_handle = self.read_handle();
+        read_handle.get(key)
+    }
+
     /// Commits uncommitted changes to the underlying trie by calling
     /// `publish()` Will wait for EACH ReadHandle to be consumed.
     fn commit_changes(&mut self) {

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -137,9 +137,9 @@ impl VrrbDb {
     }
 
     /// Updates an account on the current state tree.
-    pub fn update_account(&mut self, key: Address, args: UpdateArgs) -> Result<()> {
+    pub fn update_account(&mut self, args: UpdateArgs) -> Result<()> {
         self.state_store
-            .update(key, args)
+            .update(args)
             .map_err(|err| StorageError::Other(err.to_string()))
     }
 

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -1,7 +1,8 @@
 use std::{collections::HashMap, fmt::Display, path::PathBuf};
 
+use ethereum_types::U256;
 use lr_trie::H256;
-use primitives::{Address, NodeId};
+use primitives::Address;
 use serde_json::json;
 use storage_utils::{Result, StorageError};
 use vrrb_core::{
@@ -168,22 +169,22 @@ impl VrrbDb {
     }
 
     /// Inserts a confirmed claim to the current claim tree.
-    pub fn insert_claim_unchecked(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
-        self.claim_store.insert(node_id, claim)
+    pub fn insert_claim_unchecked(&mut self, claim: Claim) -> Result<()> {
+        self.claim_store.insert(claim)
     }
 
     /// Adds multiple claims to the current claim tree.  
-    pub fn extend_claims_unchecked(&mut self, claims: Vec<(NodeId, Claim)>) {
+    pub fn extend_claims_unchecked(&mut self, claims: Vec<(U256, Claim)>) {
         self.claim_store.extend(claims)
     }
 
     /// Inserts a confirmed claim into the claim tree.
-    pub fn insert_claim(&mut self, node_id: NodeId, claim: Claim) -> Result<()> {
-        self.claim_store.insert(node_id, claim)
+    pub fn insert_claim(&mut self, claim: Claim) -> Result<()> {
+        self.claim_store.insert(claim)
     }
 
     /// Inserts multiple claims into the current claim trie
-    pub fn extend_claims(&mut self, claims: Vec<(NodeId, Claim)>) {
+    pub fn extend_claims(&mut self, claims: Vec<(U256, Claim)>) {
         self.claim_store.extend(claims)
     }
 

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -137,19 +137,9 @@ impl VrrbDb {
     }
 
     /// Updates an account on the current state tree.
-    pub fn update_account(&mut self, key: Address, account: Account) -> Result<()> {
+    pub fn update_account(&mut self, key: Address, args: UpdateArgs) -> Result<()> {
         self.state_store
-            .update(
-                key,
-                UpdateArgs {
-                    nonce: account.nonce + 1,
-                    credits: Some(account.credits),
-                    debits: Some(account.debits),
-                    storage: Some(account.storage),
-                    code: Some(account.code),
-                    digests: Some(account.digests),
-                },
-            )
+            .update(key, args)
             .map_err(|err| StorageError::Other(err.to_string()))
     }
 
@@ -195,6 +185,11 @@ impl VrrbDb {
     /// Inserts multiple claims into the current claim trie
     pub fn extend_claims(&mut self, claims: Vec<(NodeId, Claim)>) {
         self.claim_store.extend(claims)
+    }
+
+    /// Updates a calim in the current claim trie.
+    pub fn update_claim(&mut self, _key: Address, _args: UpdateArgs) {
+        todo!()
     }
 }
 

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+
 use primitives::{Address, SecretKey};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secp256k1::{Message, Secp256k1};

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -1,6 +1,5 @@
 use std::net::SocketAddr;
-
-use primitives::{Address, NodeId, SecretKey};
+use primitives::{Address, SecretKey};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secp256k1::{Message, Secp256k1};
 use vrrb_core::{
@@ -37,9 +36,9 @@ pub fn generate_random_transaction(
 
     Txn::new(NewTxnArgs {
         timestamp: 0,
-        sender_address: from.to_string(),
+        sender_address: from.clone(),
         sender_public_key: from.public_key(),
-        receiver_address: to.to_string(),
+        receiver_address: to,
         token: None,
         amount: 100,
         signature,
@@ -50,7 +49,7 @@ pub fn generate_random_transaction(
 
 pub fn generate_random_valid_transaction() -> Txn {
     let (sender_secret_key, from) = generate_random_address();
-    let (receiver_secret_key, to) = generate_random_address();
+    let (_, to) = generate_random_address();
 
     type H = secp256k1::hashes::sha256::Hash;
 
@@ -60,9 +59,9 @@ pub fn generate_random_valid_transaction() -> Txn {
 
     Txn::new(NewTxnArgs {
         timestamp: 0,
-        sender_address: from.to_string(),
+        sender_address: from.clone(),
         sender_public_key: from.public_key(),
-        receiver_address: to.to_string(),
+        receiver_address: to,
         token: None,
         amount: 100,
         signature,

--- a/crates/storage/vrrbdb/tests/test_claim_store.rs
+++ b/crates/storage/vrrbdb/tests/test_claim_store.rs
@@ -16,20 +16,18 @@ fn claims_can_be_added() {
     let claim4 = generate_random_claim();
     let claim5 = generate_random_claim();
 
-    db.insert_claim(claim1.address.public_key().to_string(), claim1)
-        .unwrap();
+    db.insert_claim(claim1).unwrap();
 
-    db.insert_claim(claim2.address.public_key().to_string(), claim2)
-        .unwrap();
+    db.insert_claim(claim2).unwrap();
 
     let entries = db.claim_store_factory().handle().entries();
 
     assert_eq!(entries.len(), 2);
 
     db.extend_claims(vec![
-        (claim3.public_key.to_string(), claim3),
-        (claim4.public_key.to_string(), claim4),
-        (claim5.public_key.to_string(), claim5),
+        (claim3.hash, claim3),
+        (claim4.hash, claim4),
+        (claim5.hash, claim5),
     ]);
 
     let entries = db.claim_store_factory().handle().entries();

--- a/crates/storage/vrrbdb/tests/test_state_store.rs
+++ b/crates/storage/vrrbdb/tests/test_state_store.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, env, fs};
 
 use primitives::Address;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use vrrb_core::{account::Account, keypair::Keypair};
+use vrrb_core::{
+    account::{Account, AccountDigests},
+    keypair::Keypair,
+};
 use vrrbdb::{VrrbDb, VrrbDbConfig};
 
 mod common;
@@ -32,7 +35,7 @@ fn accounts_can_be_added() {
             storage: None,
             code: None,
             pubkey: vec![],
-            digests: HashMap::new(),
+            digests: AccountDigests::default(),
             created_at: 0,
             updated_at: None,
         },
@@ -49,7 +52,7 @@ fn accounts_can_be_added() {
             storage: None,
             code: None,
             pubkey: vec![],
-            digests: HashMap::new(),
+            digests: AccountDigests::default(),
             created_at: 0,
             updated_at: None,
         },
@@ -71,7 +74,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
-                digests: HashMap::new(),
+                digests: AccountDigests::default(),
                 created_at: 0,
                 updated_at: None,
             },
@@ -86,7 +89,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
-                digests: HashMap::new(),
+                digests: AccountDigests::default(),
                 created_at: 0,
                 updated_at: None,
             },
@@ -101,7 +104,7 @@ fn accounts_can_be_added() {
                 storage: None,
                 code: None,
                 pubkey: vec![],
-                digests: HashMap::new(),
+                digests: AccountDigests::default(),
                 created_at: 0,
                 updated_at: None,
             },

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -10,12 +10,12 @@ mod tests {
 
     use std::collections::HashMap;
 
-    use primitives::{AccountKeypair, Address, Signature};
+    use primitives::{Address, Signature};
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use secp256k1::ecdsa;
     use vrrb_core::{account::Account, keypair::KeyPair, txn::*};
 
-    use crate::{txn_validator::TxnValidator, validator_core_manager::ValidatorCoreManager};
+    use crate::validator_core_manager::ValidatorCoreManager;
 
     // TODO: Use proper txns when there will be proper txn validation
     // implemented
@@ -34,12 +34,18 @@ mod tests {
         .unwrap()
     }
 
-    fn random_txn(rng: &mut StdRng) -> Txn {
+    fn random_txn() -> Txn {
+        let sender_kp = KeyPair::random();
+        let recv_kp = KeyPair::random();
+
+        let sender_address = Address::new(sender_kp.get_miner_public_key().clone());
+        let recv_address = Address::new(recv_kp.get_miner_public_key().clone());
+
         Txn::new(NewTxnArgs {
             timestamp: 0,
-            sender_address: random_string(rng),
-            sender_public_key: KeyPair::random().miner_kp.1,
-            receiver_address: random_string(rng),
+            sender_address: sender_address.clone(),
+            sender_public_key: sender_kp.get_miner_public_key().clone(),
+            receiver_address: recv_address.clone(),
             token: None,
             amount: 0,
             signature: mock_txn_signature(),
@@ -49,15 +55,14 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "Needs to be rewritten to account for change in txn"]
     fn should_validate_a_list_of_invalid_transactions() {
         let mut valcore_manager = ValidatorCoreManager::new(8).unwrap();
-        let mut rng = rand::rngs::StdRng::from_seed([0; 32]);
 
         let mut batch = vec![];
 
-        let mut rng = rand::rngs::StdRng::from_seed([0; 32]);
         for _ in 0..1000 {
-            batch.push(random_txn(&mut rng));
+            batch.push(random_txn());
         }
 
         let account_state: HashMap<Address, Account> = HashMap::new();

--- a/crates/validator/src/txn_validator.rs
+++ b/crates/validator/src/txn_validator.rs
@@ -113,9 +113,9 @@ impl TxnValidator {
     /// Txn sender validator
     // TODO, to be synchronized with Wallet.
     pub fn validate_sender_address(&self, txn: &Txn) -> Result<()> {
-        if !txn.sender_address.is_empty()
-            && txn.sender_address.starts_with(ADDRESS_PREFIX)
-            && txn.sender_address.len() > 10
+        if !txn.sender_address.to_string().is_empty()
+            && txn.sender_address.to_string().starts_with(ADDRESS_PREFIX)
+            && txn.sender_address.to_string().len() > 10
         {
             Ok(())
         } else {
@@ -126,9 +126,9 @@ impl TxnValidator {
     /// Txn receiver validator
     // TODO, to be synchronized with Wallet.
     pub fn validate_receiver_address(&self, txn: &Txn) -> Result<()> {
-        if !txn.receiver_address.is_empty()
-            && txn.receiver_address.starts_with(ADDRESS_PREFIX)
-            && txn.receiver_address.len() > 10
+        if !txn.receiver_address.to_string().is_empty()
+            && txn.receiver_address.to_string().starts_with(ADDRESS_PREFIX)
+            && txn.receiver_address.to_string().len() > 10
         {
             Ok(())
         } else {
@@ -160,7 +160,7 @@ impl TxnValidator {
         txn: &Txn,
     ) -> Result<()> {
         let address = txn.sender_address.clone();
-        if let Ok(address) = secp256k1::PublicKey::from_str(address.as_str()) {
+        if let Ok(address) = secp256k1::PublicKey::from_str(address.to_string().as_str()) {
             let account = account_state.get(&Address::new(address)).unwrap();
             if (account.credits - account.debits)
                 .checked_sub(txn.amount())

--- a/crates/vrrb_core/src/account.rs
+++ b/crates/vrrb_core/src/account.rs
@@ -36,7 +36,7 @@ pub struct AccountDigests {
 }
 
 impl AccountDigests {
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         let mut len = 0;
         len += self.sent.len();
         len += self.recv.len();
@@ -48,21 +48,21 @@ impl AccountDigests {
     /// Returns the HashSet of all `TransactionDigest`s for
     /// all transactions throughout history sent by the current
     /// account
-    pub(crate) fn get_sent(&self) -> HashSet<TransactionDigest> {
+    pub fn get_sent(&self) -> HashSet<TransactionDigest> {
         self.sent.clone()
     }
 
     /// Returns the HashSet of all `TransactionDigest`s for
     /// all transactions throughout history received by the current
     /// account
-    pub(crate) fn get_recv(&self) -> HashSet<TransactionDigest> {
+    pub fn get_recv(&self) -> HashSet<TransactionDigest> {
         self.recv.clone()
     }
 
     /// Returns the HashSet of all `TransactionDigest`s for
     /// all staking transactions throughout history by the current
     /// account
-    pub(crate) fn get_stake(&self) -> HashSet<TransactionDigest> {
+    pub fn get_stake(&self) -> HashSet<TransactionDigest> {
         self.stake.clone()
     }
 

--- a/crates/vrrb_core/src/account.rs
+++ b/crates/vrrb_core/src/account.rs
@@ -324,18 +324,22 @@ impl Account {
                 self.bump_nonce();
             }
         }
+
         if let Some(credits_update) = args.credits {
             self.update_single_field_no_hash(AccountField::Credits(credits_update))?;
         }
+
         if let Some(debits_update) = args.debits {
             self.update_single_field_no_hash(AccountField::Debits(debits_update))?;
         }
+
         if let Some(code_update) = args.code {
             self.update_single_field_no_hash(AccountField::Code(code_update))?;
         }
         if let Some(storage_update) = args.storage {
             self.update_single_field_no_hash(AccountField::Storage(storage_update))?;
         }
+
         if let Some(digests) = args.digests {
             self.update_single_field_no_hash(AccountField::Digests(digests))?;
         }

--- a/crates/vrrb_core/src/account.rs
+++ b/crates/vrrb_core/src/account.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Ordering,
-    collections::HashMap,
+    collections::HashSet,
     hash::{Hash, Hasher},
 };
 
@@ -19,7 +19,69 @@ pub enum AccountField {
     Debits(u128),
     Storage(Option<String>),
     Code(Option<String>),
-    Digests(HashMap<AccountNonce, TransactionDigest>),
+    Digests(AccountDigests),
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct AccountDigests {
+    sent: HashSet<TransactionDigest>,
+    recv: HashSet<TransactionDigest>,
+    stake: HashSet<TransactionDigest>,
+}
+
+impl AccountDigests {
+    pub(crate) fn len(&self) -> usize {
+        let mut len = 0;
+        len += self.sent.len();
+        len += self.recv.len();
+        len += self.stake.len();
+
+        len
+    }
+
+    pub(crate) fn get_sent(&self) -> HashSet<TransactionDigest> {
+        self.sent.clone()
+    }
+
+    pub(crate) fn get_recv(&self) -> HashSet<TransactionDigest> {
+        self.recv.clone()
+    }
+
+    pub(crate) fn get_stake(&self) -> HashSet<TransactionDigest> {
+        self.stake.clone()
+    }
+
+    pub fn extend_all(&mut self, other: AccountDigests) {
+        self.sent.extend(other.get_sent());
+        self.recv.extend(other.get_recv());
+        self.stake.extend(other.get_stake());
+    }
+
+    pub fn insert_sent(&mut self, digest: TransactionDigest) {
+        self.sent.insert(digest);
+    }
+
+    pub fn insert_recv(&mut self, digest: TransactionDigest) {
+        self.recv.insert(digest);
+    }
+
+    pub fn insert_stake(&mut self, digest: TransactionDigest) {
+        self.stake.insert(digest);
+    }
+
+    pub fn consolidate<I: Iterator<Item = AccountDigests>>(&mut self, others: I) {
+        others.for_each(|other| self.extend_all(other))
+    }
+}
+
+impl Default for AccountDigests {
+    fn default() -> Self {
+        AccountDigests {
+            sent: HashSet::new(),
+            recv: HashSet::new(),
+            stake: HashSet::new(),
+        }
+    }
 }
 
 /// Struct representing the desired updates to be applied to account.
@@ -27,12 +89,12 @@ pub enum AccountField {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct UpdateArgs {
     pub address: Address,
-    pub nonce: u128,
+    pub nonce: Option<u128>,
     pub credits: Option<u128>,
     pub debits: Option<u128>,
     pub storage: Option<Option<String>>,
     pub code: Option<Option<String>>,
-    pub digests: Option<HashMap<AccountNonce, TransactionDigest>>,
+    pub digests: Option<AccountDigests>,
 }
 
 // The AccountFieldsUpdate will be compared by `nonce`. This way the updates can
@@ -60,11 +122,13 @@ impl Hash for UpdateArgs {
 
         if let Some(ref digests) = self.digests {
             digests.len().hash(state); // Hash the number of digests
-            let mut sorted_digests: Vec<(&AccountNonce, &TransactionDigest)> =
-                digests.iter().collect();
+            let mut consolidated_digests = digests.get_sent();
+            consolidated_digests.extend(digests.get_recv());
+            consolidated_digests.extend(digests.get_stake());
+            let mut sorted_digests: Vec<TransactionDigest> =
+                { consolidated_digests.into_iter().collect() };
             sorted_digests.sort_unstable(); // Sort digests by keys to ensure consistent hash order
-            for (key, value) in sorted_digests {
-                key.hash(state);
+            for value in sorted_digests {
                 value.hash(state);
             }
         } else {
@@ -85,7 +149,7 @@ pub struct Account {
     pub storage: Option<String>,
     pub code: Option<String>,
     pub pubkey: SerializedPublicKey,
-    pub digests: HashMap<AccountNonce, TransactionDigest>,
+    pub digests: AccountDigests,
     pub created_at: i64,
     pub updated_at: Option<i64>,
 }
@@ -98,7 +162,7 @@ impl Account {
         let debits = 0u128;
         let storage = None;
         let code = None;
-        let digests = HashMap::new();
+        let digests = AccountDigests::default();
 
         let mut hasher = Sha256::new();
         hasher.update(nonce.to_be_bytes());
@@ -164,7 +228,9 @@ impl Account {
     fn update_single_field_no_hash(&mut self, value: AccountField) -> Result<()> {
         match value {
             AccountField::Credits(credits) => match self.credits.checked_add(credits) {
-                Some(new_amount) => self.credits = new_amount,
+                Some(new_amount) => {
+                    self.credits = new_amount;
+                },
                 None => return Err(Error::Other(format!("failed to update {value:?}"))),
             },
             AccountField::Debits(debits) => match self.debits.checked_add(debits) {
@@ -193,7 +259,7 @@ impl Account {
             // if a single account has multiple transactions per round
             // better to batch them and update or at least have option to.
             AccountField::Digests(digests) => {
-                self.digests.extend(digests);
+                self.digests.extend_all(digests);
             },
         }
         Ok(())
@@ -218,11 +284,17 @@ impl Account {
     /// * `update` - An AccountFieldsUpdate struct containing instructions to
     ///   update each field of the account struct.
     pub fn update(&mut self, args: UpdateArgs) -> Result<()> {
-        if self.nonce + 1 != args.nonce {
-            return Err(Error::Other(format!(
-                "nonce from args {} is smaller than current nonce {}",
-                args.nonce, self.nonce
-            )));
+        if let Some(nonce) = args.nonce {
+            if nonce <= self.nonce {
+                return Err(Error::Other(format!(
+                    "nonce from args {} is smaller than current nonce {}",
+                    nonce, self.nonce
+                )));
+            } else if nonce > self.nonce + 1 {
+                self.update_nonce(nonce);
+            } else {
+                self.bump_nonce();
+            }
         }
         if let Some(credits_update) = args.credits {
             self.update_single_field_no_hash(AccountField::Credits(credits_update))?;
@@ -241,13 +313,16 @@ impl Account {
         }
 
         self.updated_at = Some(Utc::now().timestamp());
-        self.bump_nonce();
         self.rehash();
         Ok(())
     }
 
     pub fn bump_nonce(&mut self) {
         self.nonce += 1;
+    }
+
+    fn update_nonce(&mut self, nonce: AccountNonce) {
+        self.nonce = nonce;
     }
 }
 

--- a/crates/vrrb_core/src/account.rs
+++ b/crates/vrrb_core/src/account.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, collections::HashMap};
 
 use chrono::Utc;
-use primitives::SerializedPublicKey;
+use primitives::{Address, SerializedPublicKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -19,8 +19,10 @@ pub enum AccountField {
 }
 
 /// Struct representing the desired updates to be applied to account.
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+/// TODO: impl Default for UpdateArgs { ... }
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct UpdateArgs {
+    pub address: Address,
     pub nonce: u32,
     pub credits: Option<u128>,
     pub debits: Option<u128>,

--- a/crates/vrrb_core/src/account.rs
+++ b/crates/vrrb_core/src/account.rs
@@ -27,7 +27,7 @@ pub enum AccountField {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct UpdateArgs {
     pub address: Address,
-    pub nonce: u32,
+    pub nonce: u128,
     pub credits: Option<u128>,
     pub debits: Option<u128>,
     pub storage: Option<Option<String>>,
@@ -74,7 +74,7 @@ impl Hash for UpdateArgs {
 }
 
 
-pub type AccountNonce = u32;
+pub type AccountNonce = u128;
 
 #[derive(Clone, Default, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Account {
@@ -93,7 +93,7 @@ pub struct Account {
 impl Account {
     /// Returns new, empty account.
     pub fn new(pubkey: secp256k1::PublicKey) -> Account {
-        let nonce = 0u32;
+        let nonce = 0u128;
         let credits = 0u128;
         let debits = 0u128;
         let storage = None;

--- a/crates/vrrb_core/src/txn.rs
+++ b/crates/vrrb_core/src/txn.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::{Ord, Ordering, PartialOrd},
     collections::HashMap,
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
@@ -484,6 +485,18 @@ impl FromStr for TransactionDigest {
         let dec = Self::from(decoded);
 
         Ok(dec)
+    }
+}
+
+impl PartialOrd for TransactionDigest {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TransactionDigest {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.digest_string.cmp(&other.digest_string)
     }
 }
 

--- a/crates/vrrb_core/src/txn.rs
+++ b/crates/vrrb_core/src/txn.rs
@@ -30,6 +30,8 @@ use crate::{
         encode_to_json,
     },
 };
+
+pub const BASE_FEE: u128 = 0x2D79883D2000;
 /// This module contains the basic structure of simple transaction
 
 /// A simple custom error type
@@ -345,6 +347,18 @@ impl Txn {
         }
 
         Txn::null_txn()
+    }
+
+    pub fn get_fee(&self) -> u128 {
+        BASE_FEE
+    }
+
+    pub fn validator_fee_share(&self) -> u128 {
+        BASE_FEE / 2u128
+    }
+
+    pub fn proposer_fee_share(&self) -> u128 {
+        BASE_FEE / 2u128
     }
 
     #[deprecated(note = "will be removed from Txn struct soon")]

--- a/crates/vrrb_rpc/src/rpc/api.rs
+++ b/crates/vrrb_rpc/src/rpc/api.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use jsonrpsee::{core::Error, proc_macros::rpc};
 use primitives::{Address, NodeType};
+use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 use vrrb_core::{
     account::Account,
@@ -31,9 +32,9 @@ pub type RpcTransactionDigest = String;
 pub struct RpcTransactionRecord {
     pub id: RpcTransactionDigest,
     pub timestamp: TxTimestamp,
-    pub sender_address: String,
-    pub sender_public_key: String,
-    pub receiver_address: String,
+    pub sender_address: Address,
+    pub sender_public_key: PublicKey,
+    pub receiver_address: Address,
     pub token: Token,
     pub amount: TxAmount,
     pub signature: String,
@@ -47,7 +48,7 @@ impl From<Txn> for RpcTransactionRecord {
             id: txn.digest().to_string(),
             timestamp: txn.timestamp(),
             sender_address: txn.sender_address(),
-            sender_public_key: txn.sender_public_key().to_string(),
+            sender_public_key: txn.sender_public_key(),
             receiver_address: txn.receiver_address(),
             token: txn.token(),
             amount: txn.amount(),

--- a/crates/vrrb_rpc/tests/rpc.rs
+++ b/crates/vrrb_rpc/tests/rpc.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashMap, net::SocketAddr, str::FromStr};
+use std::{collections::HashMap, net::SocketAddr};
 
 use events::{EventMessage, DEFAULT_BUFFER};
 use primitives::{generate_account_keypair, generate_mock_account_keypair, Address};
-use secp256k1::{rand::rngs::mock, Message};
-use tokio::sync::mpsc::{channel, unbounded_channel};
-use vrrb_core::txn::{generate_txn_digest_vec, null_txn, NewTxnArgs, Token};
+use secp256k1::Message;
+use tokio::sync::mpsc::channel;
+use vrrb_core::txn::{generate_txn_digest_vec, NewTxnArgs, Token};
 use vrrb_rpc::rpc::{
     api::{RpcApiClient, RpcTransactionRecord},
     client::create_client,
@@ -30,22 +30,23 @@ async fn server_can_publish_transactions_to_be_created() {
     let client = create_client(rpc_server_address).await.unwrap();
 
     let (secret_key, public_key) = generate_mock_account_keypair();
+    let (_, recv_public_key) = generate_mock_account_keypair();
 
-    let address = Address::new(public_key);
+    let address = Address::new(public_key.clone());
+    let recv_address = Address::new(recv_public_key.clone());
 
     let timestamp = 0;
-    let sender_address = address.to_string();
+    let sender_address = address.clone();
     let sender_public_key = public_key;
-    let receiver_address = address.to_string();
     let amount = 10;
     let nonce = 0;
     let token = Token::default();
 
     let digest = generate_txn_digest_vec(
         timestamp,
-        sender_address,
+        sender_address.to_string(),
         sender_public_key,
-        receiver_address,
+        recv_address.to_string(),
         token,
         amount,
         nonce,
@@ -57,12 +58,12 @@ async fn server_can_publish_transactions_to_be_created() {
 
     let args = NewTxnArgs {
         timestamp: 0,
-        sender_address: address.to_string(),
-        sender_public_key: public_key,
-        receiver_address: address.to_string(),
+        sender_address: address.clone(),
+        sender_public_key: public_key.clone(),
+        receiver_address: recv_address.clone(),
         token: None,
         amount: 10,
-        signature,
+        signature: signature.clone(),
         validators: None,
         nonce: 0,
     };
@@ -71,26 +72,16 @@ async fn server_can_publish_transactions_to_be_created() {
 
     let mock_digest =
         "d43e21d53897192f83c2ff701cb538cf5b4d2439b93fae87b30f8ac6f07c20d1".to_string();
-    let mock_sender_address =
-        "028b0d9b8a79ef99e2d2c030123aef543ffa7e8583e480f229ae7fccd89c8ddbfa".to_string();
-    let mock_sender_public_key =
-        "028b0d9b8a79ef99e2d2c030123aef543ffa7e8583e480f229ae7fccd89c8ddbfa".to_string();
-    let mock_receiver_address =
-        "028b0d9b8a79ef99e2d2c030123aef543ffa7e8583e480f229ae7fccd89c8ddbfa".to_string();
-
-    let mock_signature=
-"30440220029d8f55b771933f5bcea06771cda9fa793478317a5633407366d3f2186ac994022012f5bdc5217f192a34a62e9856c6efd9a0803e7a93bfaefb95783da29c52c3df"
-.to_string();
 
     let mock_record = RpcTransactionRecord {
         id: mock_digest,
         timestamp: 0,
-        sender_address: mock_sender_address,
-        sender_public_key: mock_sender_public_key,
-        receiver_address: mock_receiver_address,
+        sender_address: address.clone(),
+        sender_public_key: public_key.clone(),
+        receiver_address: recv_address.clone(),
         token: Token::default(),
         amount: 10,
-        signature: mock_signature,
+        signature: signature.to_string().clone(),
         validators: HashMap::new(),
         nonce: 0,
     };

--- a/crates/wallet/tests/wallet_rpc_tests.rs
+++ b/crates/wallet/tests/wallet_rpc_tests.rs
@@ -1,10 +1,10 @@
 use std::net::SocketAddr;
 
-use primitives::{PublicKey, SecretKey};
-use secp256k1::{generate_keypair, Message, Secp256k1};
+use primitives::{generate_account_keypair, Address};
+use secp256k1::{generate_keypair, PublicKey, Secp256k1, SecretKey};
 use serial_test::serial;
-use tokio::sync::mpsc::{channel, unbounded_channel, UnboundedSender};
-use vrrb_core::{helpers::read_or_generate_keypair_file, keypair::Keypair, txn::Token};
+use tokio::sync::mpsc::channel;
+use vrrb_core::txn::Token;
 use vrrb_rpc::rpc::{JsonRpcServer, JsonRpcServerConfig};
 use wallet::v2::{Wallet, WalletConfig};
 
@@ -59,10 +59,13 @@ pub async fn wallet_sends_txn_to_rpc_server() {
 
     let timestamp = 0;
 
+    let recv_sk = SecretKey::from_hashed_data::<H>(b"recv_vrrb");
+    let recv_pk = PublicKey::from_secret_key(&secp, &recv_sk);
+
     let txn_digest = wallet
         .send_transaction(
             0,
-            "0x192abcdef01234567890fedcba09876543210".to_string(),
+            Address::new(recv_pk.clone()),
             10,
             Token::default(),
             timestamp,
@@ -72,7 +75,7 @@ pub async fn wallet_sends_txn_to_rpc_server() {
 
     assert_eq!(
         &txn_digest.to_string(),
-        "bc2de28cea998b663ed26d1b02e39ecb72c40a5fbba9c2ad66a4f9abd87f360d"
+        "0f9dc848ff611b2d09cbcca8d5143798e185db0e00f08833fd66d622dca4c039"
     );
 }
 


### PR DESCRIPTION
This PR implements methods to update accounts when there are transactions that update them. Right now this is very primitive, and tbf, a little hacky, as the structs I need to interact with don't expose the methods that are needed in order to make this a more clean implementation.

Right now there's a serious lack of code reuse, I could probably fix that a bit despite some of the shortcomings of some of the underlying structs, but don't want to engage in anti-patterns either, I think fixing the underlying structs to ensure we expose the methods needed correctly.

@nopestack and I will discuss soon, and get this cleaned up.
<hr>

### Tasks

<hr>

- [x] implement method to update tx sender account
- [x] implement method to update tx receiver account(s)
- [x] provide the `StateModule` read access to the DAG
- [x] use event in `handle` method
- [x] create method to batch updates to the same account (both to and from) into a single UpdateArg
- [x] implement a method to convert all proposal blocks in a given round into `StateUpdate` for
    - [x] Transactions
    - [x] Claims
    - [x] Fees 
- [x] implement method to gather all proposal blocks referenced by a given convergence block
- [x] When certificate of a convergence block is received, trigger method to batch update  
     - [x] `StateStore`
     - [x] `ClaimStore` 
     - [x] `TransactionStore`
 - [x] Create `Fee` variant for UpdateAccount
 - [x] Track/accumulate fees for each proposal block
     - [x] Ensure that a Fee update is created for proposer and all validators involved in the transaction 
 - [x] Check transaction against convergence block to ensure that the fee goes to the correct proposer
 - [x] Make nonce optional for `UpdateArgs` - only sender nonce increments, however, right now nonce is required in `StateUpdate` AND `UpdateArgs`
 - [x] Document all types and methods with details about what they do and why

<hr>

Deferring the following two items to their own PR (see #306):

- implement method to update claim for claim staking txs
- implement a method to convert all proposal blocks in a given round into `StateUpdate` for
    - Claim Staking

<hr>

### Everything below this has been resolved

<hr>

__EDIT__:

So the ideal design pattern here is to have a `WriteHandle` for the `StateStore` and `ClaimStore` and `TransactionStore` exposed in the `StateModule` so the thread handling the `StateModule` is the __ONE PLACE__ where writes occur, and then we can simply `get_mut(key)` for `Accounts` and `Claims` and `insert` transactions. This will take some reworking of the `StateModule`, but I think it will be worth it. Right now __ONLY__ the `TransactionStore` actually has a `WriteHandle` it appears, so this will take some work to implement for the  `StateStore` and `ClaimStore`.

__EDIT__:

I think we want a copy of the DAG in the `StateModule`, i.e. `Arc<RwLock<Bulldag>>` here, so that we don't have to send all the updates across the wire, especially since those updates may, at times, get pretty large, and we would have to request from the DAG module, all the proposal blocks once we receive the event that the ConvergenceBlock has been certified... Instead, we could simply `read` from the DAG the proposal blocks which the certified convergence block references, and get all the relevant transactions, and update them herein. We could also calculate/collect all the fees and update accounts accordingly much more smoothly as well. I think all of this will make the process much cleaner.