### PR TITLE
Add StateStore trait to abstract database consumption from Node

### DIFF
--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -309,10 +309,7 @@ async fn run_blocking(node_config: NodeConfig) -> Result<()> {
 
     let database = storage::vrrbdb::VrrbDb::new(vrrbdb_config);
 
-    let node_start_args = StartArgs {
-        config: node_config,
-        database,
-    };
+    let node_start_args = StartArgs::new(node_config, database);
 
     let vrrb_node = Node::start(node_start_args)
         .await

--- a/crates/node/src/consensus/quorum_component.rs
+++ b/crates/node/src/consensus/quorum_component.rs
@@ -4,12 +4,7 @@ use async_trait::async_trait;
 use block::header::BlockHeader;
 use ethereum_types::U256;
 use events::{
-    AssignedQuorumMembership,
-    Event,
-    EventMessage,
-    EventPublisher,
-    EventSubscriber,
-    PeerData,
+    AssignedQuorumMembership, Event, EventMessage, EventPublisher, EventSubscriber, PeerData,
 };
 use primitives::{NodeId, NodeType, QuorumKind};
 use quorum::{
@@ -105,8 +100,6 @@ impl QuorumModule {
         let event = Event::QuorumMembershipAssigmentCreated(assigned_membership).into();
 
         let em = EventMessage::new(Some("network-events".into()), event);
-
-        // dbg!(&event);
 
         self.events_tx.send(em).await?;
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -14,7 +14,6 @@ pub(crate) mod runtime;
 pub(crate) mod state_manager;
 pub(crate) mod state_reader;
 pub(crate) mod state_store;
-pub(crate) mod state_writer;
 pub(crate) mod ui;
 
 pub mod test_utils;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -13,6 +13,8 @@ pub(crate) mod network;
 pub(crate) mod runtime;
 pub(crate) mod state_manager;
 pub(crate) mod state_reader;
+pub(crate) mod state_store;
+pub(crate) mod state_writer;
 pub(crate) mod ui;
 
 pub mod test_utils;

--- a/crates/node/src/state_manager/component.rs
+++ b/crates/node/src/state_manager/component.rs
@@ -12,9 +12,7 @@ use vrrb_config::NodeConfig;
 
 use crate::{
     state_manager::{StateManager, StateManagerConfig},
-    NodeError,
-    RuntimeComponent,
-    RuntimeComponentHandle,
+    NodeError, RuntimeComponent, RuntimeComponentHandle,
 };
 
 #[derive(Debug)]

--- a/crates/node/src/state_reader.rs
+++ b/crates/node/src/state_reader.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use block::{Block, ClaimHash};
-use primitives::{Address, Round};
+use primitives::{Address, NodeId, Round};
 use storage::vrrbdb::Claims;
 use vrrb_core::{
     account::Account,
@@ -43,4 +43,12 @@ pub trait StateReader {
     async fn get_claims(&self, claim_hashes: Vec<ClaimHash>) -> Result<Claims>;
 
     async fn get_last_block(&self) -> Result<Block>;
+
+    /// Returns a copy of all values stored within the state trie
+    fn state_store_values(&self) -> HashMap<Address, Account>;
+
+    /// Returns a copy of all values stored within the state trie
+    fn transaction_store_values(&self) -> HashMap<TransactionDigest, Txn>;
+
+    fn claim_store_values(&self) -> HashMap<NodeId, Claim>;
 }

--- a/crates/node/src/state_store.rs
+++ b/crates/node/src/state_store.rs
@@ -1,8 +1,101 @@
-use crate::{state_reader::StateReader, state_writer::StateWriter};
+use std::collections::HashMap;
+
+use block::{Block, ClaimHash};
+use primitives::{Address, NodeId, Round};
+use storage::{
+    storage_utils::StorageError,
+    vrrbdb::{Claims, VrrbDb, VrrbDbReadHandle},
+};
+use vrrb_core::{
+    account::Account,
+    claim::Claim,
+    txn::{TransactionDigest, Txn},
+};
+
+use crate::{state_reader::StateReader, Result};
 
 #[async_trait::async_trait]
-pub trait StateStore {
+pub trait StateStore<S: StateReader> {
     type Error;
-    async fn write();
-    fn read();
+
+    fn state_reader(&self) -> S;
+}
+
+#[async_trait::async_trait]
+impl StateStore<VrrbDbReadHandle> for VrrbDb {
+    type Error = StorageError;
+
+    fn state_reader(&self) -> VrrbDbReadHandle {
+        self.read_handle()
+    }
+}
+
+#[async_trait::async_trait]
+impl StateReader for VrrbDbReadHandle {
+    /// Returns a full list of all accounts within state
+    async fn state_snapshot(&self) -> Result<HashMap<Address, Account>> {
+        todo!()
+    }
+
+    /// Returns a full list of transactions pending to be confirmed
+    async fn mempool_snapshot(&self) -> Result<HashMap<TransactionDigest, Txn>> {
+        todo!()
+    }
+
+    /// Get a transaction from state
+    async fn get_transaction(&self, transaction_digest: TransactionDigest) -> Result<Txn> {
+        todo!()
+    }
+
+    /// List a group of transactions
+    async fn list_transactions(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> Result<HashMap<TransactionDigest, Txn>> {
+        todo!()
+    }
+
+    async fn get_account(&self, address: Address) -> Result<Account> {
+        todo!()
+    }
+
+    async fn get_round(&self) -> Result<Round> {
+        todo!()
+    }
+
+    async fn get_blocks(&self) -> Result<Vec<Block>> {
+        todo!()
+    }
+
+    async fn get_transaction_count(&self) -> Result<usize> {
+        todo!()
+    }
+
+    async fn get_claims_by_account_id(&self) -> Result<Vec<Claim>> {
+        todo!()
+    }
+
+    async fn get_claim_hashes(&self) -> Result<Vec<ClaimHash>> {
+        todo!()
+    }
+
+    async fn get_claims(&self, claim_hashes: Vec<ClaimHash>) -> Result<Claims> {
+        todo!()
+    }
+
+    async fn get_last_block(&self) -> Result<Block> {
+        todo!()
+    }
+
+    fn state_store_values(&self) -> HashMap<Address, Account> {
+        self.state_store_values()
+    }
+
+    fn transaction_store_values(&self) -> HashMap<TransactionDigest, Txn> {
+        self.transaction_store_values()
+    }
+
+    fn claim_store_values(&self) -> HashMap<NodeId, Claim> {
+        self.claim_store_values()
+    }
 }

--- a/crates/node/src/state_store.rs
+++ b/crates/node/src/state_store.rs
@@ -1,0 +1,8 @@
+use crate::{state_reader::StateReader, state_writer::StateWriter};
+
+#[async_trait::async_trait]
+pub trait StateStore {
+    type Error;
+    async fn write();
+    fn read();
+}

--- a/crates/node/src/state_writer.rs
+++ b/crates/node/src/state_writer.rs
@@ -1,0 +1,1 @@
+pub trait StateWriter {}

--- a/crates/node/src/state_writer.rs
+++ b/crates/node/src/state_writer.rs
@@ -1,1 +1,0 @@
-pub trait StateWriter {}

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -49,7 +49,7 @@ impl Default for VrrbDbConfig {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct VrrbDb {
     state_store: StateStore,
     transaction_store: TransactionStore,

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -12,13 +12,8 @@ use vrrb_core::{
 };
 
 use crate::{
-    ClaimStore,
-    ClaimStoreReadHandleFactory,
-    StateStore,
-    StateStoreReadHandleFactory,
-    TransactionStore,
-    TransactionStoreReadHandleFactory,
-    VrrbDbReadHandle,
+    ClaimStore, ClaimStoreReadHandleFactory, StateStore, StateStoreReadHandleFactory,
+    TransactionStore, TransactionStoreReadHandleFactory, VrrbDbReadHandle,
 };
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Makes `Node` generic over a storage type to facilitate transitioning to use IntegralDB.