### PR TITLE
Initial framework for compute agent and shared service config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ path = "crates/cli/src/main.rs"
 name = "versa-wasm"
 path = "crates/wasm_cli/src/main.rs"
 
+[[bin]]
+name = "versa-compute"
+path = "crates/compute_agent/src/main.rs"
+
 [dependencies]
 tokio = { workspace = true }
 telemetry = { workspace = true }
@@ -32,6 +36,7 @@ wasm_runtime = { workspace = true }
 vrrb_rpc = { workspace = true }
 primitives = { workspace = true }
 sha2 = { workspace = true }
+service_config = { workspace = true }
 
 [workspace]
 members = [
@@ -63,6 +68,8 @@ members = [
     "crates/wasm_loader",
     "crates/wasm_cli",
     "crates/wasm_runtime",
+    "crates/compute_agent",
+    "crates/service_config",
 ]
 
 [workspace.dependencies]
@@ -100,6 +107,7 @@ vrrb_http = { path = "crates/vrrb_http" }
 vrrb_grpc = { path = "crates/vrrb_grpc" }
 wasm_loader = { path = "crates/wasm_loader" }
 wasm_runtime = { path = "crates/wasm_runtime" }
+service_config = { path = "crates/service_config" }
 
 # NOTE: Github crates
 patriecia = { git = "https://github.com/vrrb-io/patriecia" }

--- a/crates/compute_agent/Cargo.toml
+++ b/crates/compute_agent/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "compute_cli"
+description = "Verstatus Compute Agent CLI"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+telemetry = { workspace = true }
+service_config = { workspace = true }

--- a/crates/compute_agent/src/cli.rs
+++ b/crates/compute_agent/src/cli.rs
@@ -1,0 +1,44 @@
+use clap::{Parser, Subcommand};
+
+use crate::commands::daemon::DaemonOpts;
+use crate::commands::run::RunOpts;
+use crate::commands::status::StatusOpts;
+
+#[derive(Parser)]
+#[clap(author, version, about)]
+pub struct ComputeCli {
+    /// The path to the service configuration JSON file.
+    #[clap(
+        short,
+        long,
+        value_parser,
+        value_name = "FILENAME",
+        default_value = "./services.json"
+    )]
+    pub config: String,
+    /// The name of the compute service name.
+    #[clap(
+        short,
+        long,
+        value_parser,
+        value_name = "SERVICE",
+        default_value = "default"
+    )]
+    pub service: String,
+    /// The type of service definition to look up.
+    #[clap(short, long, value_parser, value_name = "TYPE")]
+    pub service_type: Option<String>,
+    /// CLI subcommand
+    #[clap(subcommand)]
+    pub cmd: Option<ComputeCommands>,
+}
+
+#[derive(Subcommand)]
+pub enum ComputeCommands {
+    /// Starts the compute agent daemon
+    Daemon(DaemonOpts),
+    /// Shows status of a running agent
+    Status(StatusOpts),
+    /// Submit a compute job for execution
+    Run(RunOpts),
+}

--- a/crates/compute_agent/src/commands/daemon/mod.rs
+++ b/crates/compute_agent/src/commands/daemon/mod.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use clap::Parser;
+use service_config::ServiceConfig;
+
+/// Structure representing command line options to the daemon subcommand
+#[derive(Parser, Debug)]
+pub struct DaemonOpts {
+}
+
+/// Start the Compute Agent Daemon
+pub async fn run(opts: &DaemonOpts, config: &ServiceConfig) -> Result<()> {
+    // XXX: This is where we should start the RPC server listener and process incoming requests
+    // using the service name and service config provided in the global command line options.
+    Ok(())
+}

--- a/crates/compute_agent/src/commands/mod.rs
+++ b/crates/compute_agent/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod daemon;
+pub mod run;
+pub mod status;

--- a/crates/compute_agent/src/commands/status/mod.rs
+++ b/crates/compute_agent/src/commands/status/mod.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use clap::Parser;
+use service_config::ServiceConfig;
+
+/// Command line options structure for status subcommand
+#[derive(Parser, Debug)]
+pub struct StatusOpts {
+}
+
+/// Make a status RPC query against a running agent.
+pub async fn run(opts: &StatusOpts, config: &ServiceConfig) -> Result<()> {
+    // XXX: This where we would make the status RPC call to the named service (global option) from
+    // the service config file (global option) and show the result.
+    Ok(())
+}

--- a/crates/compute_agent/src/main.rs
+++ b/crates/compute_agent/src/main.rs
@@ -1,0 +1,43 @@
+mod cli;
+mod commands;
+
+use anyhow::Result;
+use clap::Parser;
+use tokio;
+use service_config::Config;
+use telemetry::info;
+
+const THIS_SERVICE_TYPE: &str = "compute";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = cli::ComputeCli::parse();
+
+    let service: String;
+    match cli.service_type {
+        Some(svc) => service = svc.clone(),
+        None => service = THIS_SERVICE_TYPE.to_string(),
+    }
+
+    // Parse common services configuration
+    let config = Config::from_file(&cli.config)?
+        .find_service(&cli.service, &service)?;
+
+    info!("Matched service {}:{} to config: {:?}", cli.service, service, config);
+
+    // Process subcommand
+    match &cli.cmd {
+        Some(cli::ComputeCommands::Daemon(opts)) => {
+            commands::daemon::run(opts, &config).await?;
+        },
+        Some(cli::ComputeCommands::Status(opts)) => {
+            commands::status::run(opts, &config).await?;
+        },
+        Some(cli::ComputeCommands::Run(opts)) => {
+            commands::run::run(opts, &config).await?;
+        },
+        None => {},
+    }
+
+    Ok(())
+}

--- a/crates/service_config/Cargo.toml
+++ b/crates/service_config/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "service_config"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/service_config/src/lib.rs
+++ b/crates/service_config/src/lib.rs
@@ -1,0 +1,84 @@
+use anyhow::{anyhow, Result};
+use serde_derive::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::BufReader;
+
+/// High level wrapper struct to allow us to add things to this configuration file later that
+/// aren't network service parameters. Some runtime-configuration parameters are best suited as
+/// command line options, but others (especially those we will later wish to manage
+/// programmatically) are better suited to an on-disk configuration file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Config {
+    /// The services network configuration entries.
+    pub services: ServiceCollectionConfig,
+}
+
+/// A structure representing the entire collection of the ServiceConfigs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceCollectionConfig {
+    /// List of compute node endpoints
+    pub compute: Vec<ServiceConfig>,
+    /// List of blob-storage node endpoints
+    pub storage: Vec<ServiceConfig>,
+    /// List of blockchain/protocol node endpoints
+    pub blockchain: Vec<ServiceConfig>,
+}
+
+/// A structure representing the necessary configuration items required for a network service
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceConfig {
+    /// The name of this service definition
+    pub name: String,
+    /// The address to bind to for RPC calls
+    pub rpc_address: String,
+    /// The port to bind to for RPC calls
+    pub rpc_port: u32,
+    /// A preshared key for authenticating RPC calls
+    pub pre_shared_key: String,
+    /// A TLS private key for RPC transport privacy
+    pub tls_private_key_file: String,
+    /// A TLS public certificate for RPC transport privacy
+    pub tls_public_cert_file: String,
+    /// A TLS CA certificate for validating certificates
+    pub tls_ca_cert_file: String,
+}
+
+impl Config {
+    /// Given a JSON file representing a service configuration collection, return an object.
+    pub fn from_file(filename: &str) -> Result<Self> {
+        let file = File::open(filename)?;
+        let reader = BufReader::new(file);
+        Ok(serde_json::from_reader(reader)?)
+    }
+
+    /// Find a service definition by type and label
+    pub fn find_service(&self, service_name: &str, service_type: &str) -> Result<ServiceConfig> {
+        let collection: Vec<ServiceConfig>;
+        match service_type {
+            "compute" => {
+                collection = self.services.compute.clone();
+            },
+            "storage" => {
+                collection = self.services.storage.clone();
+            },
+            "blockchain" => {
+                collection = self.services.blockchain.clone();
+            },
+            _ => return Err(anyhow!("Invalid service type: {}", service_type)),
+        }
+
+        for svc in collection.iter() {
+            if svc.name == service_name {
+                return Ok(svc.clone());
+            }
+        }
+        Err(anyhow!(
+            "Service {} not found as a {} service",
+            service_name,
+            service_type
+        ))
+    }
+}

--- a/tools/sample-configs/README.md
+++ b/tools/sample-configs/README.md
@@ -1,0 +1,10 @@
+# Sample Configs
+
+This directory contains sample configuration files that may be used as defaults or modified to suit a given deployment. Descriptions of each follow.
+
+## services.json
+
+This configuration file is used by the storage agent, the compute agent and (perhaps) the protocol service for defining RPC endpoints within a given operator's deployment. It is used, for example, for RPC clients to determine which address, port and secret key to use to communicate with specific services over RPC. It is also used by RPC services to know which RPC address and port to bind to and which secret key to use when authenticating incoming client requests.
+
+The default file is suitable for deployments where all three (compute, protocol and storage) services are running on the same machine. All that is required is to change each of the pre-shared keys to a random string each.
+

--- a/tools/sample-configs/services.json
+++ b/tools/sample-configs/services.json
@@ -1,0 +1,31 @@
+{
+  "services": {
+    "compute": [ {
+      "name": "compute1",
+      "rpcAddress": "::1",
+      "rpcPort": 9125,
+      "preSharedKey": "<random string>",
+      "tlsPrivateKeyFile": "",
+      "tlsPublicCertFile": "",
+      "tlsCaCertFile": ""
+    } ],
+    "storage": [ {
+      "name": "storage1",
+      "rpcAddress": "::1",
+      "rpcPort": 9126,
+      "preSharedKey": "<random string>",
+      "tlsPrivateKeyFile": "",
+      "tlsPublicCertFile": "",
+      "tlsCaCertFile": ""
+    } ],
+    "blockchain": [ {
+      "name": "blockchain1",
+      "rpcAddress": "::1",
+      "rpcPort": 9124,
+      "preSharedKey": "<random string>",
+      "tlsPrivateKeyFile": "",
+      "tlsPublicCertFile": "",
+      "tlsCaCertFile": ""
+    } ]
+  }
+}


### PR DESCRIPTION
This pull request just lays out the command line parsing and service config stuff that'll be needed for starting the RPC server and making a couple of CLI-based RPC client requests. It's really just stubs for now, but the compute agent RPCs ought to fit right into it once ready. The service config stuff is designed to be reused/resuable by the storage agent too, and the protocol service if we want to go for consistency.