### PR TITLE
Add `NodeId` to `Claim`

### DIFF
--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -9,7 +9,7 @@ mod tests {
         net::SocketAddr,
     };
 
-    use primitives::Address;
+    use primitives::{Address, NodeId};
     use sha256::digest;
     use vrrb_core::{claim::Claim, keypair::KeyPair};
 
@@ -34,8 +34,14 @@ mod tests {
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
 
             //let claim_box = Box::new(claim);
             dummy_claims.push(claim);
@@ -75,8 +81,14 @@ mod tests {
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
 
             dummy_claims.push(claim);
         });
@@ -111,8 +123,14 @@ mod tests {
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -144,8 +162,14 @@ mod tests {
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -181,8 +205,14 @@ mod tests {
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
             dummy_claims.push(claim);
         });
 
@@ -218,8 +248,14 @@ mod tests {
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
             dummy_claims.push(claim);
         });
         let keypair = KeyPair::random();
@@ -259,8 +295,14 @@ mod tests {
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim: Claim =
-                Claim::new(public_key, Address::new(public_key), ip_address, signature).unwrap();
+            let claim: Claim = Claim::new(
+                public_key,
+                Address::new(public_key),
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
             //let boxed_claim = Box::new(claim);
             dummy_claims1.push(claim.clone());
             dummy_claims2.push(claim.clone());

--- a/crates/miner/src/lib.rs
+++ b/crates/miner/src/lib.rs
@@ -16,7 +16,7 @@ mod tests {
 
     use block::{Block, ProposalBlock};
     use bulldag::vertex::Vertex;
-    use primitives::Address;
+    use primitives::{Address, NodeId};
     use ritelinked::LinkedHashMap;
     use vrrb_core::{
         claim::Claim,
@@ -25,16 +25,10 @@ mod tests {
     };
 
     use crate::test_helpers::{
-        build_single_proposal_block,
-        build_single_proposal_block_from_txns,
-        create_and_sign_message,
-        create_miner,
-        create_miner_from_keypair,
-        create_miner_from_keypair_and_dag,
-        create_miner_from_keypair_return_dag,
-        create_miner_return_dag,
-        create_txns,
-        mine_genesis,
+        build_single_proposal_block, build_single_proposal_block_from_txns,
+        create_and_sign_message, create_miner, create_miner_from_keypair,
+        create_miner_from_keypair_and_dag, create_miner_from_keypair_return_dag,
+        create_miner_return_dag, create_txns, mine_genesis,
     };
 
     #[test]
@@ -53,6 +47,7 @@ mod tests {
             address.clone(),
             ip_address,
             signature,
+            NodeId::default(),
         )
         .unwrap();
         let miner = create_miner_from_keypair(&kp);

--- a/crates/miner/src/miner.rs
+++ b/crates/miner/src/miner.rs
@@ -12,7 +12,7 @@ use block::{
 };
 use bulldag::graph::BullDag;
 use ethereum_types::U256;
-use primitives::{Address, Epoch, PublicKey, Signature};
+use primitives::{Address, Epoch, NodeId, PublicKey, Signature};
 use reward::reward::Reward;
 use ritelinked::{LinkedHashMap, LinkedHashSet};
 use secp256k1::{
@@ -163,7 +163,7 @@ impl Miner {
     ///
     /// assert_eq!(miner.unwrap().address(), address);
     /// ```
-    pub fn new(config: MinerConfig) -> Result<Self> {
+    pub fn new(config: MinerConfig, node_id: NodeId) -> Result<Self> {
         let address = Address::new(config.public_key);
         let signature = Claim::signature_for_valid_claim(
             config.public_key,
@@ -176,6 +176,7 @@ impl Miner {
             address.clone(),
             config.ip_address,
             signature,
+            node_id,
         )
         .map_err(MinerError::from)?;
         Ok(Miner {
@@ -218,6 +219,7 @@ impl Miner {
             self.public_key(),
             self.address(),
             self.ip_address(),
+            self.claim.node_id.clone(),
             signature,
         )
         .map_err(MinerError::from)?;

--- a/crates/miner/src/test_helpers.rs
+++ b/crates/miner/src/test_helpers.rs
@@ -6,7 +6,7 @@ use std::{
 use block::{Block, GenesisBlock, InnerBlock, ProposalBlock};
 use bulldag::{graph::BullDag, vertex::Vertex};
 use ethereum_types::U256;
-use primitives::{Address, PublicKey, SecretKey, Signature};
+use primitives::{Address, NodeId, PublicKey, SecretKey, Signature};
 use ritelinked::LinkedHashMap;
 use secp256k1::Message;
 use sha2::Digest;
@@ -32,7 +32,7 @@ pub fn create_miner() -> Miner {
         ip_address,
         dag,
     };
-    Miner::new(config).unwrap()
+    Miner::new(config, NodeId::default()).unwrap()
 }
 
 /// Helper function to create a miner from a `Keypair`
@@ -46,7 +46,7 @@ pub fn create_miner_from_keypair(kp: &Keypair) -> Miner {
         public_key,
         dag,
     };
-    Miner::new(config).unwrap()
+    Miner::new(config, NodeId::default()).unwrap()
 }
 
 pub fn create_miner_from_keypair_return_dag(kp: &Keypair) -> (Miner, MinerDag) {
@@ -80,7 +80,7 @@ pub fn create_claim(
     ip_address: SocketAddr,
     signature: String,
 ) -> Claim {
-    Claim::new(*pk, addr.clone(), ip_address, signature).unwrap()
+    Claim::new(*pk, addr.clone(), ip_address, signature, NodeId::default()).unwrap()
 }
 
 /// Helper function to create a random message and signature
@@ -251,7 +251,14 @@ pub fn build_multiple_proposal_blocks_single_round(
                 keypair.get_miner_secret_key().secret_bytes().to_vec(),
             )
             .unwrap();
-            let claim = Claim::new(public_key, address, ip_address, signature).unwrap();
+            let claim = Claim::new(
+                public_key,
+                address,
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
             let prop = build_single_proposal_block(
                 last_block_hash.clone(),
                 n_txns,

--- a/crates/node/src/mining_module.rs
+++ b/crates/node/src/mining_module.rs
@@ -173,6 +173,7 @@ impl RuntimeComponent<MiningModuleComponentConfig, ()> for MiningModule {
         let mut miner_events_rx = args.miner_events_rx;
         let mempool_read_handle_factory = args.mempool_read_handle_factory;
         let dag = args.dag;
+        let node_id = config.id.clone();
 
         let (_, miner_secret_key) = config.keypair.get_secret_keys();
         let (_, miner_public_key) = config.keypair.get_public_keys();
@@ -185,7 +186,7 @@ impl RuntimeComponent<MiningModuleComponentConfig, ()> for MiningModule {
             dag,
         };
 
-        let miner = miner::Miner::new(miner_config).map_err(NodeError::from)?;
+        let miner = miner::Miner::new(miner_config, node_id).map_err(NodeError::from)?;
         let module_config = MiningModuleConfig {
             miner,
             events_tx,

--- a/crates/node/src/runtime.rs
+++ b/crates/node/src/runtime.rs
@@ -63,6 +63,7 @@ pub async fn setup_runtime_components(
         Address::new(public_key),
         config.public_ip_address,
         signature,
+        config.id.clone(),
     )
     .map_err(NodeError::from)?;
 

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -123,7 +123,14 @@ fn produce_random_claims(n: usize) -> HashSet<Claim> {
             )
             .unwrap();
 
-            Claim::new(kp.miner_kp.1, address, ip_address, signature).unwrap()
+            Claim::new(
+                kp.miner_kp.1,
+                address,
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap()
         })
         .collect()
 }
@@ -178,7 +185,14 @@ pub fn produce_proposal_blocks(
             )
             .unwrap();
 
-            let from = Claim::new(kp.miner_kp.1, address, ip_address, signature).unwrap();
+            let from = Claim::new(
+                kp.miner_kp.1,
+                address,
+                ip_address,
+                signature,
+                NodeId::default(),
+            )
+            .unwrap();
             let txs = produce_random_txs(&accounts);
             let claims = produce_random_claims(ntx);
 

--- a/crates/storage/vrrbdb/tests/common.rs
+++ b/crates/storage/vrrbdb/tests/common.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use primitives::{Address, SecretKey};
+use primitives::{Address, NodeId, SecretKey};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use secp256k1::{Message, Secp256k1};
 use vrrb_core::{
@@ -86,6 +86,7 @@ pub fn _generate_random_claim() -> Claim {
         Address::new(public_key),
         ip_address.clone(),
         signature,
+        NodeId::default(),
     )
     .unwrap()
 }

--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use ethereum_types::U256;
-use primitives::{Address, PublicKey, SerializedSecretKey};
+use primitives::{Address, NodeId, PublicKey, SerializedSecretKey};
 use serde::{Deserialize, Serialize};
 /// a Module for creating, maintaining, and using a claim in the fair,
 /// computationally inexpensive, collission proof, fully decentralized, fully
@@ -50,6 +50,7 @@ pub struct Claim {
     pub eligibility: Eligibility,
     pub ip_address: SocketAddr,
     pub signature: String,
+    pub node_id: NodeId,
     stake: u128,
     stake_txns: Vec<Stake>,
 }
@@ -81,6 +82,7 @@ impl Claim {
         address: Address,
         ip_address: SocketAddr,
         signature: String,
+        node_id: NodeId,
     ) -> Result<Claim> {
         let mut hasher = Sha256::new();
         hasher.update(public_key.to_string());
@@ -103,6 +105,7 @@ impl Claim {
                 eligibility: Eligibility::None,
                 ip_address,
                 signature,
+                node_id,
                 stake: 0,
                 stake_txns: vec![],
             }),
@@ -393,10 +396,18 @@ mod tests {
             eligibility: Eligibility::None,
             ip_address: "127.0.0.1:8080".parse().unwrap(),
             signature: signature.clone(),
+            node_id: NodeId::default(),
             stake: 0,
             stake_txns: vec![],
         };
-        let claim = Claim::new(public_key, address, ip_address, signature).unwrap();
+        let claim = Claim::new(
+            public_key,
+            address,
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
         assert_eq!(test_claim, claim);
     }
 
@@ -415,7 +426,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim = Claim::new(public_key.clone(), address, ip_address, signature).unwrap();
+        let mut claim = Claim::new(
+            public_key.clone(),
+            address,
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let ip_address_new = "127.0.0.1:8081".parse::<SocketAddr>().unwrap();
         let mut hasher_new = Sha256::new();
@@ -447,7 +465,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let claim = Claim::new(public_key, address, ip_address, signature).unwrap();
+        let claim = Claim::new(
+            public_key,
+            address,
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
         assert_eq!(0, claim.get_stake());
     }
 
@@ -466,7 +491,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let claim = Claim::new(public_key, address, ip_address, signature).unwrap();
+        let claim = Claim::new(
+            public_key,
+            address,
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
         assert_eq!(0, claim.get_stake_txns().len());
     }
 
@@ -496,7 +528,14 @@ mod tests {
 
         let test_election_result = U256(xor_val);
 
-        let claim = Claim::new(public_key, address, ip_address, signature).unwrap();
+        let claim = Claim::new(
+            public_key,
+            address,
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let election_result = claim.get_election_result(seed);
 
@@ -518,7 +557,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim = Claim::new(public_key, address.clone(), ip_address, signature).unwrap();
+        let mut claim = Claim::new(
+            public_key,
+            address.clone(),
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let amount = StakeUpdate::Add(10_000u128);
 
@@ -550,7 +596,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim = Claim::new(public_key, address.clone(), ip_address, signature).unwrap();
+        let mut claim = Claim::new(
+            public_key,
+            address.clone(),
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let amount = StakeUpdate::Add(10_000u128);
 
@@ -584,8 +637,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim =
-            Claim::new(public_key, address.clone(), ip_address.clone(), signature).unwrap();
+        let mut claim = Claim::new(
+            public_key,
+            address.clone(),
+            ip_address.clone(),
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let amount = StakeUpdate::Add(10_000u128);
 
@@ -619,7 +678,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim = Claim::new(public_key, address.clone(), ip_address, signature).unwrap();
+        let mut claim = Claim::new(
+            public_key,
+            address.clone(),
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
         let amount = StakeUpdate::Add(10_000u128);
         let mut stake = Stake::new(
             amount,
@@ -668,7 +734,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim = Claim::new(public_key, address.clone(), ip_address, signature).unwrap();
+        let mut claim = Claim::new(
+            public_key,
+            address.clone(),
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let amount = StakeUpdate::Withdrawal(5_000u128);
         let mut stake = Stake::new(
@@ -702,7 +775,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim = Claim::new(public_key, address.clone(), ip_address, signature).unwrap();
+        let mut claim = Claim::new(
+            public_key,
+            address.clone(),
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let amount = StakeUpdate::Add(10_000u128);
 
@@ -753,7 +833,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim = Claim::new(public_key, address.clone(), ip_address, signature).unwrap();
+        let mut claim = Claim::new(
+            public_key,
+            address.clone(),
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let amount = StakeUpdate::Slash(25u8);
         let mut stake = Stake::new(
@@ -787,7 +874,14 @@ mod tests {
             kp.get_miner_secret_key().secret_bytes().to_vec(),
         )
         .unwrap();
-        let mut claim = Claim::new(public_key, address.clone(), ip_address, signature).unwrap();
+        let mut claim = Claim::new(
+            public_key,
+            address.clone(),
+            ip_address,
+            signature,
+            NodeId::default(),
+        )
+        .unwrap();
 
         let amount = StakeUpdate::Add(10_000u128);
 


### PR DESCRIPTION
Adds `NodeId` field to `Claim` for use in the `entries` method on `ClaimStoreReadHandleFactory`.

relevant PR #442 
