### PR TITLE
Fix `generate_transfer_digest_vec` imports

### DIFF
--- a/crates/node/src/runtime/node_runtime.rs
+++ b/crates/node/src/runtime/node_runtime.rs
@@ -30,7 +30,7 @@ use vrrb_core::{
     account::{Account, UpdateArgs},
     claim::Claim,
     transactions::{
-        generate_txn_digest_vec, NewTransferArgs, Token, Transaction, TransactionDigest,
+        generate_transfer_digest_vec, NewTransferArgs, Token, Transaction, TransactionDigest,
         TransactionKind, Transfer,
     },
 };

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -370,8 +370,8 @@ pub async fn send_data_over_quic(data: String, addr: SocketAddr) -> Result<()> {
 
 use rand::{seq::SliceRandom, thread_rng};
 use vrrb_core::transactions::{
-    generate_txn_digest_vec, NewTransferArgs, QuorumCertifiedTxn, Transaction, TransactionDigest,
-    TransactionKind, Transfer,
+    generate_transfer_digest_vec, NewTransferArgs, QuorumCertifiedTxn, Transaction,
+    TransactionDigest, TransactionKind, Transfer,
 };
 
 pub fn generate_nodes_pattern(n: usize) -> Vec<NodeType> {


### PR DESCRIPTION
Fixes some imports causing compilation to fail.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Renamed the function `generate_txn_digest_vec` to `generate_transfer_digest_vec` in `node_runtime.rs` and `test_utils.rs` for better clarity and understanding of its purpose. This change does not affect any existing functionalities or interfaces, but improves code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->