### PR TITLE
bug: Remove GRPC from builder & config

### DIFF
--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -121,7 +121,6 @@ impl From<RunOpts> for NodeConfig {
             http_api_version: opts.http_api_version,
             http_api_shutdown_timeout: default_node_config.http_api_shutdown_timeout,
             jsonrpc_server_address: opts.jsonrpc_api_address,
-            grpc_server_address: opts.grpc_server_address,
             preload_mock_state: default_node_config.preload_mock_state,
             bootstrap_config: default_node_config.bootstrap_config,
             kademlia_liveness_address: default_node_config.kademlia_liveness_address,

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -42,7 +42,6 @@ pub fn create_mock_full_node_config() -> NodeConfig {
     let jsonrpc_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let rendezvous_local_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let rendezvous_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
-    let grpc_server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 50051);
     let public_ip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let udp_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
     let raptorq_gossip_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
@@ -69,7 +68,6 @@ pub fn create_mock_full_node_config() -> NodeConfig {
         .kademlia_peer_id(Some(KademliaPeerId::rand()))
         .kademlia_liveness_address(kademlia_liveness_address)
         .public_ip_address(public_ip_address)
-        .grpc_server_address(grpc_server_address)
         .disable_networking(false)
         .quorum_config(None)
         .bootstrap_quorum_config(None)

--- a/crates/vrrb_config/src/node_config.rs
+++ b/crates/vrrb_config/src/node_config.rs
@@ -71,10 +71,6 @@ pub struct NodeConfig {
     /// Address the node listens for JSON-RPC connections
     pub jsonrpc_server_address: SocketAddr,
 
-    /// Address the node listens for gRPC connections
-    #[deprecated(note = "deprecated in favor of the JSON-RPC API")]
-    pub grpc_server_address: SocketAddr,
-
     // TODO: refactor env-aware options
     #[builder(default = "false")]
     pub preload_mock_state: bool,
@@ -172,7 +168,6 @@ impl Default for NodeConfig {
             http_api_version: String::from("v.0.1.0"),
             http_api_shutdown_timeout: None,
             jsonrpc_server_address: ipv4_localhost_with_random_port,
-            grpc_server_address: ipv4_localhost_with_random_port,
             preload_mock_state: false,
             bootstrap_config: None,
             quorum_config: None,


### PR DESCRIPTION
Removes code pertaining to deprecated grpc causing tests to fail.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Removed the deprecated `grpc_server_address` field from the `NodeConfig` struct across multiple files. This change simplifies the node configuration and aligns with our shift towards using the JSON-RPC API exclusively, eliminating the need for a separate gRPC server address. Users should now rely solely on the JSON-RPC API for their interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->