### PR TITLE
Refactor `Vote`, remove use of quorum key & threshold

### DIFF
--- a/crates/events/src/event_data.rs
+++ b/crates/events/src/event_data.rs
@@ -55,8 +55,6 @@ pub struct Vote {
     /// Partial Signature
     pub signature: RawSignature,
     pub txn: TransactionKind,
-    pub quorum_public_key: Vec<u8>,
-    pub quorum_threshold: usize,
     pub is_txn_valid: bool,
     // May want to serialize this as a vector of bytes
     pub execution_result: Option<String>,

--- a/crates/node/src/consensus/consensus_module.rs
+++ b/crates/node/src/consensus/consensus_module.rs
@@ -366,12 +366,12 @@ impl ConsensusModule {
 
         let sig_provider = &self.sig_provider;
 
-        let farmer_quorum_threshold = self.quorum_public_keyset()?.threshold();
-        let quorum_public_key = self
-            .quorum_public_keyset()?
-            .public_key()
-            .to_bytes()
-            .to_vec();
+        // let farmer_quorum_threshold = self.quorum_public_keyset()?.threshold();
+        // let quorum_public_key = self
+        //     .quorum_public_keyset()?
+        //     .public_key()
+        //     .to_bytes()
+        //     .to_vec();
 
         let votes = validated_txns
             .par_iter()
@@ -388,8 +388,6 @@ impl ConsensusModule {
                     farmer_node_id,
                     signature,
                     txn: new_txn,
-                    quorum_public_key: quorum_public_key.clone(),
-                    quorum_threshold: farmer_quorum_threshold as usize,
                     execution_result: None,
                     is_txn_valid: validation_result.is_err(),
                 })
@@ -411,82 +409,83 @@ impl ConsensusModule {
         validated_txns.iter().any(|x| x.0.id() == txn.id())
     }
 
-    pub fn validate_votes(
-        &mut self,
-        votes: Vec<Vote>,
-        quorum_threshold: FarmerQuorumThreshold,
-        accounts_state: &HashMap<Address, Account>,
-    ) {
-        for vote in votes.iter() {
-            self.validate_vote(vote.clone(), quorum_threshold, accounts_state);
-        }
-    }
+    // TODO: Refactor without use of quorum public key
+    // pub fn validate_votes(
+    //     &mut self,
+    //     votes: Vec<Vote>,
+    //     quorum_threshold: FarmerQuorumThreshold,
+    //     accounts_state: &HashMap<Address, Account>,
+    // ) {
+    //     for vote in votes.iter() {
+    //         self.validate_vote(vote.clone(), quorum_threshold, accounts_state);
+    //     }
+    // }
 
-    // The above code is handling an event of type `Vote` in a Rust
-    // program. It checks the integrity of the vote by
-    // verifying that it comes from the actual voter and prevents
-    // double voting. It then adds the vote to a pool of votes for the
-    // corresponding transaction and farmer quorum key. If
-    // the number of votes in the pool reaches the farmer
-    // quorum threshold, it sends a job to certify the transaction
-    // using the provided signature provider.
-    pub fn validate_vote(
-        &mut self,
-        vote: Vote,
-        farmer_quorum_threshold: FarmerQuorumThreshold,
-        accounts_state: &HashMap<Address, Account>,
-    ) -> Result<()> {
-        // TODO: Harvester quorum nodes should check the integrity of the vote by verifying the vote does
-        // come from the alleged voter Node.
+    // // The above code is handling an event of type `Vote` in a Rust
+    // // program. It checks the integrity of the vote by
+    // // verifying that it comes from the actual voter and prevents
+    // // double voting. It then adds the vote to a pool of votes for the
+    // // corresponding transaction and farmer quorum key. If
+    // // the number of votes in the pool reaches the farmer
+    // // quorum threshold, it sends a job to certify the transaction
+    // // using the provided signature provider.
+    // pub fn validate_vote(
+    //     &mut self,
+    //     vote: Vote,
+    //     farmer_quorum_threshold: FarmerQuorumThreshold,
+    //     accounts_state: &HashMap<Address, Account>,
+    // ) -> Result<()> {
+    //     // TODO: Harvester quorum nodes should check the integrity of the vote by verifying the vote does
+    //     // come from the alleged voter Node.
 
-        let sig_provider = self.sig_provider.clone();
+    //     let sig_provider = self.sig_provider.clone();
 
-        let farmer_quorum_key = hex::encode(vote.quorum_public_key.clone());
-        let key = (vote.txn.id(), farmer_quorum_key.clone());
+    //     let farmer_quorum_key = hex::encode(vote.quorum_public_key.clone());
+    //     let key = (vote.txn.id(), farmer_quorum_key.clone());
 
-        let mut votes = self.votes_pool.get_mut(&key);
+    //     let mut votes = self.votes_pool.get_mut(&key);
 
-        if let Some(mut votes) = self.votes_pool.get_mut(&key) {
-            if self.certified_txns_filter.contains(&key) {
-                return Err(NodeError::Other(
-                    "Transaction was already certified by a Harvester Node".into(),
-                ));
-            }
+    //     if let Some(mut votes) = self.votes_pool.get_mut(&key) {
+    //         if self.certified_txns_filter.contains(&key) {
+    //             return Err(NodeError::Other(
+    //                 "Transaction was already certified by a Harvester Node".into(),
+    //             ));
+    //         }
 
-            votes.push(vote.clone());
+    //         votes.push(vote.clone());
 
-            if votes.len() < farmer_quorum_threshold {
-                return Err(NodeError::Other(format!(
-                    "Not enough votes to certify transaction {}",
-                    vote.txn.id()
-                )));
-            }
+    //         if votes.len() < farmer_quorum_threshold {
+    //             return Err(NodeError::Other(format!(
+    //                 "Not enough votes to certify transaction {}",
+    //                 vote.txn.id()
+    //             )));
+    //         }
 
-            let vote_shares = Self::group_votes_by_validity(&votes);
+    //         let vote_shares = Self::group_votes_by_validity(&votes);
 
-            // NOTE: revalidate the transaction because Harvesters cant trust Farmers
-            let validated = self
-                .validate_transactions(accounts_state, vec![vote.txn.clone()])
-                .iter()
-                .any(|(validated_txn, _)| validated_txn.id() == vote.txn.id());
+    //         // NOTE: revalidate the transaction because Harvesters cant trust Farmers
+    //         let validated = self
+    //             .validate_transactions(accounts_state, vec![vote.txn.clone()])
+    //             .iter()
+    //             .any(|(validated_txn, _)| validated_txn.id() == vote.txn.id());
 
-            if validated {
-                self.handle_validated_vote(
-                    &sig_provider,
-                    &vote_shares,
-                    &vote.txn,
-                    farmer_quorum_threshold,
-                    &farmer_quorum_key,
-                );
-            } else {
-                error!("Penalize Farmer for wrong votes by sending Wrong Vote event to CR Quorum");
-            }
-        } else {
-            self.votes_pool.insert(key, vec![vote]);
-        }
+    //         if validated {
+    //             self.handle_validated_vote(
+    //                 &sig_provider,
+    //                 &vote_shares,
+    //                 &vote.txn,
+    //                 farmer_quorum_threshold,
+    //                 &farmer_quorum_key,
+    //             );
+    //         } else {
+    //             error!("Penalize Farmer for wrong votes by sending Wrong Vote event to CR Quorum");
+    //         }
+    //     } else {
+    //         self.votes_pool.insert(key, vec![vote]);
+    //     }
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     fn group_votes_by_validity(votes: &[Vote]) -> HashMap<bool, BTreeMap<NodeId, Vec<u8>>> {
         let mut vote_shares: HashMap<bool, BTreeMap<NodeId, Vec<u8>>> = HashMap::new();

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -756,13 +756,13 @@ mod tests {
                     .unwrap();
             }
         }
-        for (_, node) in validator_nodes.iter_mut() {
-            let quorum_kind = node.quorum_membership().unwrap().quorum_kind;
-            if quorum_kind == QuorumKind::Farmer || quorum_kind == QuorumKind::Harvester {
-                node.generate_keysets()
-                    .expect(&format!("failed to generate keyset for node {}", node.id));
-            }
-        }
+        // for (_, node) in validator_nodes.iter_mut() {
+        //     let quorum_kind = node.quorum_membership().unwrap().quorum_kind;
+        //     if quorum_kind == QuorumKind::Farmer || quorum_kind == QuorumKind::Harvester {
+        //         node.generate_keysets()
+        //             .expect(&format!("failed to generate keyset for node {}", node.id));
+        //     }
+        // }
 
         let mut farmer_nodes = validator_nodes
             .clone()

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -315,6 +315,20 @@ impl Handler<EventMessage> for NodeRuntime {
             //         };
             //     }
             // },
+            Event::TxnAddedToMempool(txn_hash) => {
+                if let Ok(votes) = self.validate_mempool(1) {
+                    self.events_tx
+                        .send(Event::TransactionsValidated { 
+                            votes, 
+                            quorum_threshold: self.config.threshold_config.threshold
+                        }).into()
+                        .await
+                        .map_err(|err| TheaterError::Other(err.to_string()))?;
+                }
+            },
+            Event::TransactionsValidated { votes, quorum_threshold } => {
+                // TODO: Send Votes to Harvester Nodes
+            },
             Event::NoOp => {},
             _ => {},
         }

--- a/crates/vrrb_config/src/bootstrap_quorum.rs
+++ b/crates/vrrb_config/src/bootstrap_quorum.rs
@@ -20,6 +20,8 @@ pub type QuorumMembers = BTreeMap<NodeId, QuorumMember>;
 pub struct QuorumMembershipConfig {
     pub quorum_kind: QuorumKind,
     pub quorum_members: BTreeMap<NodeId, QuorumMember>,
+    // TODO: This might be the place to put quorum info:q
+    //
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
Removes some fields on `Vote` that were being used incorrectly causing some tests to fail. This isn't a solution, but a band-aid to make progress toward alphanet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Removed `quorum_public_key` and `quorum_threshold` fields from the `Vote` struct in `event_data.rs`.
- Chore: Commented out code related to quorum validation in `consensus_module.rs` for future refactoring.
- Chore: Temporarily disabled keyset generation for nodes in `mod.rs`.
- New Feature: Added `TxnAddedToMempool` and `TransactionsValidated` event handlers in `node_runtime_handler.rs` for improved transaction validation and processing.
- Documentation: Added comment in `bootstrap_quorum.rs` suggesting a potential location for storing quorum information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->