### PR TITLE
[WIP] Modify consensus module to handle votes

### DIFF
--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -9,7 +9,7 @@ use std::{
 
 use hbbft::crypto::PublicKeySet;
 use hex::FromHexError;
-use primitives::{RawSignature, QuorumType,NodeId};
+use primitives::{NodeId, QuorumType, RawSignature};
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;
 use ritelinked::{LinkedHashMap, LinkedHashSet};
@@ -46,10 +46,10 @@ pub type ResolvedConflicts = Vec<JoinHandle<Result<Conflict, Box<dyn Error>>>>;
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[repr(C)]
 pub struct QuorumData {
-   pub id: QuorumId,
-   pub quorum_type: QuorumType,
-   pub members: HashSet<NodeId>,
-   pub quorum_pubkey: PublicKeySet
+    pub id: QuorumId,
+    pub quorum_type: QuorumType,
+    pub members: HashSet<NodeId>,
+    pub quorum_pubkey: PublicKeySet,
 }
 
 impl std::hash::Hash for QuorumData {
@@ -57,7 +57,7 @@ impl std::hash::Hash for QuorumData {
         self.id.hash(state);
         self.quorum_type.hash(state);
         let members: Vec<NodeId> = self.members.clone().into_iter().collect();
-        members.hash(state); 
+        members.hash(state);
         self.quorum_pubkey.hash(state);
     }
 }

--- a/crates/block/src/types.rs
+++ b/crates/block/src/types.rs
@@ -7,8 +7,9 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+use hbbft::crypto::PublicKeySet;
 use hex::FromHexError;
-use primitives::RawSignature;
+use primitives::{RawSignature, QuorumType,NodeId};
 #[cfg(mainnet)]
 use reward::reward::GENESIS_REWARD;
 use ritelinked::{LinkedHashMap, LinkedHashSet};
@@ -38,15 +39,34 @@ pub type ConsolidatedClaims = LinkedHashMap<RefHash, LinkedHashSet<ClaimHash>>;
 pub type BlockHash = String;
 pub type QuorumId = String;
 pub type QuorumPubkey = String;
-pub type QuorumPubkeys = LinkedHashMap<QuorumId, QuorumPubkey>;
+pub type QuorumMembers = LinkedHashMap<QuorumId, QuorumData>;
 pub type ConflictList = HashMap<TransactionDigest, Conflict>;
 pub type ResolvedConflicts = Vec<JoinHandle<Result<Conflict, Box<dyn Error>>>>;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[repr(C)]
+pub struct QuorumData {
+   pub id: QuorumId,
+   pub quorum_type: QuorumType,
+   pub members: HashSet<NodeId>,
+   pub quorum_pubkey: PublicKeySet
+}
+
+impl std::hash::Hash for QuorumData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.quorum_type.hash(state);
+        let members: Vec<NodeId> = self.members.clone().into_iter().collect();
+        members.hash(state); 
+        self.quorum_pubkey.hash(state);
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[repr(C)]
 pub struct Certificate {
     pub signature: String,
-    pub inauguration: Option<QuorumPubkeys>,
+    pub inauguration: Option<QuorumMembers>,
     pub root_hash: String,
     pub next_root_hash: String,
     pub block_hash: String,

--- a/crates/consensus/dkg_engine/src/dkg.rs
+++ b/crates/consensus/dkg_engine/src/dkg.rs
@@ -1,5 +1,5 @@
 use hbbft::{
-    crypto::PublicKey,
+    crypto::{PublicKey, PublicKeySet},
     sync_key_gen::{Ack, Part},
 };
 use primitives::NodeId;
@@ -22,7 +22,7 @@ pub trait DkgGenerator {
 
     fn handle_ack_messages(&mut self) -> Result<()>; //Handle all ACK Messages from all other k-1 MasterNodes
 
-    fn generate_key_sets(&mut self) -> Result<()>;
+    fn generate_key_sets(&mut self) -> Result<Option<PublicKeySet>>;
 
     fn add_peer_public_key(&mut self, node_id: NodeId, public_key: PublicKey);
 

--- a/crates/consensus/dkg_engine/src/engine.rs
+++ b/crates/consensus/dkg_engine/src/engine.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use hbbft::{
-    crypto::{PublicKey, SecretKey, PublicKeySet},
+    crypto::{PublicKey, PublicKeySet, SecretKey},
     sync_key_gen::{Ack, Part, PartOutcome, SyncKeyGen},
 };
 use primitives::{NodeId, NodeType, ValidatorPublicKey};
@@ -173,7 +173,7 @@ impl DkgGenerator for DkgEngine {
             .insert(node_id.clone(), part_commitment.clone());
 
         self.dkg_state.set_sync_key_gen(Some(sync_key_gen));
-        
+
         // part_commitment has to be multicasted to all Farmers/Harvester Peers
         // within the Quorum
         Ok((part_commitment, self.node_id()))

--- a/crates/consensus/dkg_engine/src/engine.rs
+++ b/crates/consensus/dkg_engine/src/engine.rs
@@ -173,7 +173,8 @@ impl DkgGenerator for DkgEngine {
             .insert(node_id.clone(), part_commitment.clone());
 
         self.dkg_state.set_sync_key_gen(Some(sync_key_gen));
-
+        
+        dbg!("generated part commitment, multicasted to all Farmer/Harverster Peers within quorum: {}", &part_commitment);
         // part_commitment has to be multicasted to all Farmers/Harvester Peers
         // within the Quorum
         Ok((part_commitment, self.node_id()))

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use block::QuorumMembers;
 use block::{
     header::BlockHeader, Block, BlockHash, Certificate, ConvergenceBlock, ProposalBlock, RefHash,
 };
@@ -281,6 +282,7 @@ pub enum Event {
     /// object representing a proof that a block has been certified by a
     /// quorum. This certificate is then added to convergence block .
     BlockCertificateCreated(Certificate),
+    QuorumMembersReceived(QuorumMembers) 
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use block::QuorumMembers;
+use block::{QuorumMembers, QuorumData};
 use block::{
     header::BlockHeader, Block, BlockHash, Certificate, ConvergenceBlock, ProposalBlock, RefHash,
 };
@@ -282,7 +282,8 @@ pub enum Event {
     /// object representing a proof that a block has been certified by a
     /// quorum. This certificate is then added to convergence block .
     BlockCertificateCreated(Certificate),
-    QuorumMembersReceived(QuorumMembers) 
+    QuorumMembersReceived(QuorumMembers),
+    QuorumFormed(PublicKeySet),
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -283,7 +283,8 @@ pub enum Event {
     /// quorum. This certificate is then added to convergence block .
     BlockCertificateCreated(Certificate),
     QuorumMembersReceived(QuorumMembers),
-    QuorumFormed(PublicKeySet),
+    QuorumFormed,
+    BroadcastQuorumFormed(QuorumData),
 }
 
 impl From<&theater::Message> for Event {

--- a/crates/node/src/consensus/consensus_event_handler.rs
+++ b/crates/node/src/consensus/consensus_event_handler.rs
@@ -7,7 +7,10 @@ use dkg_engine::{
 };
 use ethereum_types::U256;
 use events::{AssignedQuorumMembership, PeerData, Vote};
-use hbbft::{sync_key_gen::{Ack, Part}, crypto::PublicKeySet};
+use hbbft::{
+    crypto::PublicKeySet,
+    sync_key_gen::{Ack, Part},
+};
 use maglev::Maglev;
 use primitives::{
     ByteSlice48Bit, FarmerQuorumThreshold, NodeId, NodeType, ProgramExecutionOutput,

--- a/crates/node/src/consensus/consensus_event_handler.rs
+++ b/crates/node/src/consensus/consensus_event_handler.rs
@@ -7,7 +7,7 @@ use dkg_engine::{
 };
 use ethereum_types::U256;
 use events::{AssignedQuorumMembership, PeerData, Vote};
-use hbbft::sync_key_gen::{Ack, Part};
+use hbbft::{sync_key_gen::{Ack, Part}, crypto::PublicKeySet};
 use maglev::Maglev;
 use primitives::{
     ByteSlice48Bit, FarmerQuorumThreshold, NodeId, NodeType, ProgramExecutionOutput,
@@ -173,7 +173,7 @@ impl ConsensusModule {
         Ok(())
     }
 
-    pub fn generate_keysets(&mut self) -> Result<()> {
+    pub fn generate_keysets(&mut self) -> Result<Option<PublicKeySet>> {
         self.dkg_engine
             .generate_key_sets()
             .map_err(|err| NodeError::Other(err.to_string()))

--- a/crates/node/src/consensus/consensus_module.rs
+++ b/crates/node/src/consensus/consensus_module.rs
@@ -12,8 +12,9 @@ use hbbft::{
 };
 use mempool::TxnStatus;
 use primitives::{
-    Address, ByteVec, FarmerQuorumThreshold, GroupPublicKey, NodeId, NodeIdx, NodeType,
+    Address, ByteVec, FarmerQuorumThreshold, GroupPublicKey, NodeId, NodeType,
     NodeTypeBytes, PKShareBytes, PayloadBytes, QuorumPublicKey, RawSignature, ValidatorPublicKey,
+    QuorumId, QuorumType
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -33,8 +34,6 @@ use crate::{NodeError, Result};
 pub const PULL_TXN_BATCH_SIZE: usize = 100;
 
 // TODO: Move this to primitives
-pub type QuorumId = String;
-pub type QuorumPubkey = String;
 
 #[derive(Debug)]
 pub struct ConsensusModuleConfig {
@@ -87,11 +86,14 @@ pub struct ConsensusModule {
     pub(crate) sig_provider: SignatureProvider,
     pub(crate) convergence_block_certificates:
         Cache<BlockHash, HashSet<(NodeId, PublicKeyShare, RawSignature)>>,
-
+    pub(crate) current_quorums: HashMap<QuorumId, (QuorumType, HashMap<NodeId, PublicKeySet>)>,
+    pub(crate) current_quorum_pubkeys: HashMap<QuorumId, QuorumPublicKey>,
+    pub(crate) quorum_membership: Option<QuorumId>,
+    pub(crate) quorum_type: Option<QuorumType>,
     // NOTE: harvester types
     // pub certified_txns_filter: Bloom,
     // pub votes_pool: DashMap<(TransactionDigest, String), Vec<Vote>>,
-    pub votes_pool: HashMap<(TransactionDigest, String), Vec<Vote>>,
+    pub votes_pool: HashMap<QuorumId, HashMap<TransactionDigest, HashSet<Vote>>>,
     pub group_public_key: GroupPublicKey,
     // pub sig_provider: Option<SignatureProvider>,
     // pub(crate) vrrbdb_read_handle: VrrbDbReadHandle,
@@ -127,6 +129,10 @@ impl ConsensusModule {
                 cfg.node_config.threshold_config.clone(),
             ),
             convergence_block_certificates: Cache::new(10, 300),
+            current_quorums: HashMap::new(),
+            current_quorum_pubkeys: HashMap::new(),
+            quorum_membership: None,
+            quorum_type: None,
             validator_core_manager,
             votes_pool: Default::default(),
             group_public_key: Default::default(),
@@ -407,6 +413,78 @@ impl ConsensusModule {
             .validate(&accounts_state, vec![txn.clone()]);
 
         validated_txns.iter().any(|x| x.0.id() == txn.id())
+    }
+
+    pub fn insert_vote_into_vote_pool(&mut self, vote: Vote) -> Result<()> {
+        self.is_quorum_member()?;
+        self.is_harvester()?;
+
+        if let Some((quorum_id, QuorumType::Farmer)) = self.get_node_quorum_id(&vote.farmer_id) {
+            let nested_map = self.votes_pool.entry(quorum_id).or_insert_with(HashMap::new);
+            let digest = vote.txn.id();
+            let vote_set = nested_map.entry(digest).or_insert_with(HashSet::new);
+            vote_set.insert(vote);
+            return Ok(())
+        }
+
+        return Err(
+            NodeError::Other(
+                format!(
+                    "node is not a member of currently active quorum"
+                )
+            )
+        )
+    }
+
+    fn get_node_quorum_id(&self, node_id: &NodeId) -> Option<(QuorumId, QuorumType)> {
+        for (quorum_id, nested_map) in self.current_quorums.iter() {
+            if nested_map.1.contains_key(node_id) {
+                return Some((quorum_id.clone(), nested_map.0.clone()))
+            }
+        }
+        None
+    }
+
+    fn is_quorum_member(&self) -> Result<()> {
+        if self.quorum_membership.is_none() {
+            return Err(
+                NodeError::Other(
+                    format!(
+                        "local node is not a quorum member"
+                    )
+                )
+            )
+        }
+
+        Ok(())
+    }
+
+    fn is_harvester(&self) -> Result<()> {
+        if self.quorum_type.is_none() || self.quorum_type != Some(QuorumType::Harvester) {
+            return Err(
+                NodeError::Other(
+                    format!(
+                        "local node is not a Harvester Node"
+                    )
+                )
+            )
+        }
+
+        Ok(())
+    }
+
+    fn is_farmer(&self) -> Result<()> {
+        if self.quorum_type.is_none() || self.quorum_type != Some(QuorumType::Farmer) {
+            return Err(
+                NodeError::Other(
+                    format!(
+                        "local node is not a Harvester Node"
+                    )
+                )
+            )
+        }
+
+        Ok(())
     }
 
     // TODO: Refactor without use of quorum public key

--- a/crates/node/src/network/handler.rs
+++ b/crates/node/src/network/handler.rs
@@ -78,7 +78,7 @@ impl Handler<EventMessage> for NetworkModule {
                 self.node_ref().kill();
                 return Ok(ActorState::Stopped);
             },
-            Event::QuorumFormed(quorum_data) => {
+            Event::BroadcastQuorumFormed(quorum_data) => {
                 info!("Broadcasting quorum information to network");
                 self.broadcast_quorum_membership(quorum_data).await?;
             }

--- a/crates/node/src/network/handler.rs
+++ b/crates/node/src/network/handler.rs
@@ -78,6 +78,10 @@ impl Handler<EventMessage> for NetworkModule {
                 self.node_ref().kill();
                 return Ok(ActorState::Stopped);
             },
+            Event::QuorumFormed(quorum_data) => {
+                info!("Broadcasting quorum information to network");
+                self.broadcast_quorum_membership(quorum_data).await?;
+            }
             _ => {},
         }
 

--- a/crates/node/src/network/module.rs
+++ b/crates/node/src/network/module.rs
@@ -397,4 +397,22 @@ impl NetworkModule {
 
         Ok(())
     }
+
+    pub async fn broadcast_quorum_membership(
+        &mut self,
+        quorum_data: hbbft::crypto::PublicKeySet, 
+    ) -> Result<()> {
+        let message = dyswarm::types::Message::new(NetworkEvent::QuorumFormed(quorum_data));
+
+        self.dyswarm_client
+            .broadcast(
+                BroadcastArgs {
+                    config: Default::default(),
+                    message,
+                    erasure_count: 0,
+                }
+            ).await?;
+
+        Ok(())
+    }
 }

--- a/crates/node/src/network/module.rs
+++ b/crates/node/src/network/module.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use block::ConvergenceBlock;
+use block::{ConvergenceBlock, QuorumData};
 use dyswarm::{
     client::{BroadcastArgs, BroadcastConfig},
     server::ServerConfig,
@@ -400,9 +400,9 @@ impl NetworkModule {
 
     pub async fn broadcast_quorum_membership(
         &mut self,
-        quorum_data: hbbft::crypto::PublicKeySet, 
+        quorum_data: QuorumData, 
     ) -> Result<()> {
-        let message = dyswarm::types::Message::new(NetworkEvent::QuorumFormed(quorum_data));
+        let message = dyswarm::types::Message::new(NetworkEvent::BroadcastQuorumFormed(quorum_data));
 
         self.dyswarm_client
             .broadcast(

--- a/crates/node/src/network/network_event.rs
+++ b/crates/node/src/network/network_event.rs
@@ -1,9 +1,9 @@
 use std::net::SocketAddr;
 
-use block::ConvergenceBlock;
+use block::{ConvergenceBlock, QuorumData};
 use events::AssignedQuorumMembership;
 use hbbft::{
-    crypto::PublicKey,
+    crypto::{PublicKey, PublicKeySet},
     sync_key_gen::{Ack, Part},
 };
 use mempool::TxnRecord;
@@ -60,7 +60,7 @@ pub enum NetworkEvent {
     },
 
     ConvergenceBlockCertified(ConvergenceBlock),
-
+    QuorumFormed(PublicKeySet),
     Ping(NodeId),
 
     #[default]

--- a/crates/node/src/network/network_event.rs
+++ b/crates/node/src/network/network_event.rs
@@ -60,7 +60,7 @@ pub enum NetworkEvent {
     },
 
     ConvergenceBlockCertified(ConvergenceBlock),
-    QuorumFormed(PublicKeySet),
+    BroadcastQuorumFormed(QuorumData),
     Ping(NodeId),
 
     #[default]

--- a/crates/node/src/runtime/component.rs
+++ b/crates/node/src/runtime/component.rs
@@ -28,7 +28,9 @@ impl RuntimeComponent<NodeRuntimeComponentConfig, NodeRuntimeComponentResolvedDa
         args: NodeRuntimeComponentConfig,
     ) -> crate::Result<RuntimeComponentHandle<NodeRuntimeComponentResolvedData>> {
         let mut events_rx = args.events_rx;
-        let node_runtime = NodeRuntime::new(&args.config, args.events_tx).await?;
+        let node_runtime = NodeRuntime::new(&args.config, args.events_tx).await.map_err(|err| {
+            NodeError::Other(err.to_string())
+        })?;
 
         let state_read_handle = node_runtime.state_read_handle();
         let mempool_read_handle_factory = node_runtime.mempool_read_handle_factory();

--- a/crates/node/src/runtime/handler_helpers.rs
+++ b/crates/node/src/runtime/handler_helpers.rs
@@ -159,26 +159,31 @@ impl NodeRuntime {
             .collect();
         let id = self.consensus_driver.quorum_membership.clone();
         let quorum_type = self.consensus_driver.quorum_type.clone();
-        let quorum_pubkey = self.consensus_driver.dkg_engine.dkg_state
-            .public_key_set().clone(); 
-        
+        let quorum_pubkey = self
+            .consensus_driver
+            .dkg_engine
+            .dkg_state
+            .public_key_set()
+            .clone();
+
         if let (Some(id), Some(quorum_pubkey), Some(quorum_type)) =
             (id.clone(), quorum_pubkey.clone(), quorum_type.clone())
         {
             let quorum_data = QuorumData {
-                id,
+                id: id.get_inner(),
                 quorum_type,
                 members,
                 quorum_pubkey,
             };
             self.events_tx
-                .send(events::Event::QuorumFormed.into())
+                .send(events::Event::BroadcastQuorumFormed(quorum_data).into())
                 .await?;
 
             Ok(())
         } else {
             Err(NodeError::Other(
-                "consensus driver missing one of quorum id, quorum public key, or quorum type".into(),
+                "consensus driver missing one of quorum id, quorum public key, or quorum type"
+                    .into(),
             ))
         }
     }

--- a/crates/node/src/runtime/handler_helpers.rs
+++ b/crates/node/src/runtime/handler_helpers.rs
@@ -172,7 +172,7 @@ impl NodeRuntime {
                 quorum_pubkey,
             };
             self.events_tx
-                .send(events::Event::QuorumFormed(quorum_data).into())
+                .send(events::Event::QuorumFormed.into())
                 .await?;
 
             Ok(())

--- a/crates/node/src/runtime/handler_helpers.rs
+++ b/crates/node/src/runtime/handler_helpers.rs
@@ -13,7 +13,7 @@ use bulldag::graph::BullDag;
 use dkg_engine::prelude::{DkgEngine, DkgEngineConfig, ReceiverId, SenderId};
 use ethereum_types::U256;
 use events::{AssignedQuorumMembership, EventPublisher, PeerData};
-use hbbft::sync_key_gen::{Ack, Part};
+use hbbft::{sync_key_gen::{Ack, Part}, crypto::PublicKeySet};
 use mempool::{LeftRightMempool, MempoolReadHandleFactory, TxnRecord};
 use miner::{Miner, MinerConfig};
 use primitives::{
@@ -143,6 +143,16 @@ impl NodeRuntime {
         //         }
         //
         todo!()
+    }
+
+    pub async fn handle_quorum_formed(&mut self, quorum_data: PublicKeySet) -> Result<()> {
+        self.events_tx.send(
+            events::Event::QuorumFormed(
+                quorum_data
+            ).into()
+        ).await?;
+
+        Ok(())
     }
 
     pub async fn handle_node_added_to_peer_list(

--- a/crates/node/src/runtime/handler_helpers.rs
+++ b/crates/node/src/runtime/handler_helpers.rs
@@ -148,7 +148,7 @@ impl NodeRuntime {
         todo!()
     }
 
-    pub async fn handle_quorum_formed(&mut self, quorum_data: PublicKeySet) -> Result<()> {
+    pub async fn handle_quorum_formed(&mut self) -> Result<()> {
         let members: std::collections::HashSet<NodeId> = self
             .consensus_driver
             .dkg_engine
@@ -159,17 +159,13 @@ impl NodeRuntime {
             .collect();
         let id = self.consensus_driver.quorum_membership.clone();
         let quorum_type = self.consensus_driver.quorum_type.clone();
-        let quorum_pubkey = self
-            .consensus_driver
-            .dkg_engine
-            .dkg_state
-            .public_key_set()
-            .clone();
-
+        let quorum_pubkey = self.consensus_driver.dkg_engine.dkg_state
+            .public_key_set().clone(); 
+        
         if let (Some(id), Some(quorum_pubkey), Some(quorum_type)) =
             (id.clone(), quorum_pubkey.clone(), quorum_type.clone())
         {
-            let _full_quorum_data = QuorumData {
+            let quorum_data = QuorumData {
                 id,
                 quorum_type,
                 members,
@@ -182,7 +178,7 @@ impl NodeRuntime {
             Ok(())
         } else {
             Err(NodeError::Other(
-                "consensus driver missing quorum id".into(),
+                "consensus driver missing one of quorum id, quorum public key, or quorum type".into(),
             ))
         }
     }

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -118,7 +118,7 @@ mod tests {
     use std::collections::HashMap;
     use std::ops::AddAssign;
 
-    use block::{Block, ConvergenceBlock};
+    use block::{Block, ConvergenceBlock, QuorumId};
     use events::{AssignedQuorumMembership, Event, PeerData, DEFAULT_BUFFER};
     use hbbft::sync_key_gen::{AckOutcome, Part};
     use primitives::{generate_account_keypair, Address, NodeId, NodeType, QuorumKind};
@@ -316,6 +316,12 @@ mod tests {
         for node in farmer_nodes.iter_mut() {
             node.generate_keysets().await.unwrap();
         }
+        let ids: Vec<&primitives::QuorumId> = farmer_nodes
+            .iter()
+            .map(|node| node.consensus_driver.quorum_membership.as_ref().unwrap())
+            .collect();
+        dbg!(&ids);
+        assert_eq!(ids[0], ids[1]);
     }
 
     #[tokio::test]

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -215,7 +215,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn validator_node_runtimes_can_generate_a_shared_key() {
-        let (events_tx, _) = tokio::sync::mpsc::channel(DEFAULT_BUFFER);
+        let (events_tx, _rx) = tokio::sync::mpsc::channel(DEFAULT_BUFFER);
 
         let mut nodes = create_node_runtime_network(4, events_tx.clone()).await;
 
@@ -314,7 +314,6 @@ mod tests {
             node.handle_all_ack_messages().unwrap();
         }
         for node in farmer_nodes.iter_mut() {
-            dbg!(&node.consensus_driver.dkg_engine.dkg_state.public_key_set());
             node.generate_keysets().await.unwrap();
         }
     }

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -316,7 +316,7 @@ mod tests {
         for node in farmer_nodes.iter_mut() {
             node.generate_keysets().unwrap();
 
-            dbg!(&node.consensus_driver.dkg_engine.dkg_state.public_key_set());
+            //dbg!(&node.consensus_driver.dkg_engine.dkg_state.public_key_set());
         }
     }
 

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -314,9 +314,8 @@ mod tests {
             node.handle_all_ack_messages().unwrap();
         }
         for node in farmer_nodes.iter_mut() {
+            dbg!(&node.consensus_driver.dkg_engine.dkg_state.public_key_set());
             node.generate_keysets().await.unwrap();
-
-            //dbg!(&node.consensus_driver.dkg_engine.dkg_state.public_key_set());
         }
     }
 

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -314,7 +314,7 @@ mod tests {
             node.handle_all_ack_messages().unwrap();
         }
         for node in farmer_nodes.iter_mut() {
-            node.generate_keysets().unwrap();
+            node.generate_keysets().await.unwrap();
 
             //dbg!(&node.consensus_driver.dkg_engine.dkg_state.public_key_set());
         }
@@ -604,7 +604,7 @@ mod tests {
         run_dkg_process(farmers);
     }
 
-    fn run_dkg_process(mut nodes: HashMap<NodeId, NodeRuntime>) {
+    async fn run_dkg_process(mut nodes: HashMap<NodeId, NodeRuntime>) {
         let mut parts = HashMap::new();
 
         for (node_id, node) in nodes.iter_mut() {
@@ -657,7 +657,7 @@ mod tests {
         }
 
         for (_, node) in nodes.iter_mut() {
-            node.generate_keysets().unwrap();
+            node.generate_keysets().await.unwrap();
         }
     }
 

--- a/crates/node/src/runtime/node_runtime.rs
+++ b/crates/node/src/runtime/node_runtime.rs
@@ -238,7 +238,6 @@ impl NodeRuntime {
             //TODO: maybe give consensus_driver an EventsPublisher so that 
             //it can directly emit this event
             self.events_tx.send(Event::QuorumFormed(pks).into()).await?;
-            
         }
 
         Ok(())

--- a/crates/node/src/runtime/node_runtime.rs
+++ b/crates/node/src/runtime/node_runtime.rs
@@ -242,11 +242,11 @@ impl NodeRuntime {
     }
 
     pub async fn generate_keysets(&mut self) -> Result<()> {
-        if let Ok(Some(pks)) = self.consensus_driver.generate_keysets() {
+        if let Ok(Some(_)) = self.consensus_driver.generate_keysets() {
             //TODO: share quorum members instead of pks
             //TODO: maybe give consensus_driver an EventsPublisher so that
             //it can directly emit this event
-            self.events_tx.send(Event::QuorumFormed(pks).into()).await?
+            self.events_tx.send(Event::QuorumFormed.into()).await?;
         }
 
         Ok(())

--- a/crates/node/src/runtime/node_runtime.rs
+++ b/crates/node/src/runtime/node_runtime.rs
@@ -246,8 +246,7 @@ impl NodeRuntime {
             //TODO: share quorum members instead of pks
             //TODO: maybe give consensus_driver an EventsPublisher so that
             //it can directly emit this event
-            dbg!(self.events_tx.is_closed());
-            self.events_tx.send(Event::QuorumFormed(pks).into()).await?;
+            self.events_tx.send(Event::QuorumFormed(pks).into()).await?
         }
 
         Ok(())

--- a/crates/node/src/runtime/node_runtime.rs
+++ b/crates/node/src/runtime/node_runtime.rs
@@ -242,7 +242,8 @@ impl NodeRuntime {
     }
 
     pub async fn generate_keysets(&mut self) -> Result<()> {
-        if let Ok(Some(_)) = self.consensus_driver.generate_keysets() {
+        if let Ok(Some(pks)) = self.consensus_driver.generate_keysets() {
+            self.consensus_driver.assign_quorum_id(pks);
             //TODO: share quorum members instead of pks
             //TODO: maybe give consensus_driver an EventsPublisher so that
             //it can directly emit this event

--- a/crates/node/src/runtime/node_runtime.rs
+++ b/crates/node/src/runtime/node_runtime.rs
@@ -61,7 +61,7 @@ pub struct NodeRuntime {
 }
 
 impl NodeRuntime {
-    pub async fn new(config: &NodeConfig, events_tx: EventPublisher) -> Result<Self> {
+    pub async fn new(config: &NodeConfig, events_tx: EventPublisher) -> std::result::Result<Self, anyhow::Error> {
         let dag: Arc<RwLock<BullDag<Block, String>>> = Arc::new(RwLock::new(BullDag::new()));
 
         let miner_public_key = config.keypair.get_miner_public_key().to_owned();
@@ -157,11 +157,11 @@ impl NodeRuntime {
         self.config.clone()
     }
 
-    fn _setup_reputation_module() -> Result<Option<JoinHandle<Result<()>>>> {
+    fn _setup_reputation_module() -> std::result::Result<Option<JoinHandle<Result<()>>>, anyhow::Error> {
         Ok(None)
     }
 
-    fn _setup_credit_model_module() -> Result<Option<JoinHandle<Result<()>>>> {
+    fn _setup_credit_model_module() -> std::result::Result<Option<JoinHandle<Result<()>>>, anyhow::Error> {
         Ok(None)
     }
 
@@ -512,7 +512,7 @@ impl NodeRuntime {
 
     /// Validates a batch of up to n transactions within a Node's mempool.
     /// This function is meant to be triggered at a configurable interval
-    pub fn validate_mempool(&mut self, n: usize) -> Result<Vec<Vote>> {
+    pub fn validate_mempool(&mut self, n: usize) -> std::result::Result<Vec<Vote>, anyhow::Error> {
         self.has_required_node_type(NodeType::Validator, "validate transactions")?;
         self.belongs_to_correct_quorum(QuorumKind::Farmer, "validate transactions")?;
 

--- a/crates/node/src/runtime/node_runtime.rs
+++ b/crates/node/src/runtime/node_runtime.rs
@@ -13,7 +13,10 @@ use bulldag::graph::BullDag;
 use dkg_engine::prelude::{DkgEngine, DkgEngineConfig, ReceiverId, SenderId};
 use ethereum_types::U256;
 use events::{AssignedQuorumMembership, Event, EventPublisher, PeerData, Vote};
-use hbbft::{sync_key_gen::{Ack, Part}, crypto::PublicKeySet};
+use hbbft::{
+    crypto::PublicKeySet,
+    sync_key_gen::{Ack, Part},
+};
 use mempool::{LeftRightMempool, MempoolReadHandleFactory, TxnRecord};
 use miner::{Miner, MinerConfig};
 use primitives::{
@@ -39,8 +42,9 @@ use vrrb_core::{
 use crate::{
     consensus::{ConsensusModule, ConsensusModuleConfig},
     mining_module::{MiningModule, MiningModuleConfig},
+    network::NetworkEvent,
     result::{NodeError, Result},
-    state_manager::{DagModule, StateManager, StateManagerConfig}, network::NetworkEvent,
+    state_manager::{DagModule, StateManager, StateManagerConfig},
 };
 
 pub const PULL_TXN_BATCH_SIZE: usize = 100;
@@ -61,7 +65,10 @@ pub struct NodeRuntime {
 }
 
 impl NodeRuntime {
-    pub async fn new(config: &NodeConfig, events_tx: EventPublisher) -> std::result::Result<Self, anyhow::Error> {
+    pub async fn new(
+        config: &NodeConfig,
+        events_tx: EventPublisher,
+    ) -> std::result::Result<Self, anyhow::Error> {
         let dag: Arc<RwLock<BullDag<Block, String>>> = Arc::new(RwLock::new(BullDag::new()));
 
         let miner_public_key = config.keypair.get_miner_public_key().to_owned();
@@ -157,11 +164,13 @@ impl NodeRuntime {
         self.config.clone()
     }
 
-    fn _setup_reputation_module() -> std::result::Result<Option<JoinHandle<Result<()>>>, anyhow::Error> {
+    fn _setup_reputation_module(
+    ) -> std::result::Result<Option<JoinHandle<Result<()>>>, anyhow::Error> {
         Ok(None)
     }
 
-    fn _setup_credit_model_module() -> std::result::Result<Option<JoinHandle<Result<()>>>, anyhow::Error> {
+    fn _setup_credit_model_module(
+    ) -> std::result::Result<Option<JoinHandle<Result<()>>>, anyhow::Error> {
         Ok(None)
     }
 
@@ -235,8 +244,9 @@ impl NodeRuntime {
     pub async fn generate_keysets(&mut self) -> Result<()> {
         if let Ok(Some(pks)) = self.consensus_driver.generate_keysets() {
             //TODO: share quorum members instead of pks
-            //TODO: maybe give consensus_driver an EventsPublisher so that 
+            //TODO: maybe give consensus_driver an EventsPublisher so that
             //it can directly emit this event
+            dbg!(self.events_tx.is_closed());
             self.events_tx.send(Event::QuorumFormed(pks).into()).await?;
         }
 

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -1,5 +1,3 @@
-use std::collections::{BTreeMap, HashSet};
-
 use async_trait::async_trait;
 use dkg_engine::dkg::DkgGenerator;
 use events::{Event, EventMessage, EventPublisher, EventSubscriber, Vote};
@@ -265,8 +263,16 @@ impl Handler<EventMessage> for NodeRuntime {
                 self.handle_block_certificate_created(certificate)
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
             },
-//            Event::HarvesterPublicKeyReceived(public_key_set) => self
-//               .handle_harvester_public_key_received(public_key_set),
+            Event::QuorumFormed(quorum_data) => {
+                self.events_tx.send(
+                    Event::QuorumFormed(
+                        quorum_data
+                    ).into()
+                ).await.map_err(|err| {
+                    TheaterError::Other(err.to_string())
+                })?;
+                // TODO: Replace above with call to self.handle_quorum_formed().
+            },
             Event::QuorumMembersReceived(quorum_members) => self
                 .state_driver.handle_quorum_members_received(quorum_members),
             // Event::ElectedMiner((_winner_claim_hash, winner_claim)) => {

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -264,11 +264,10 @@ impl Handler<EventMessage> for NodeRuntime {
                 self.handle_block_certificate_created(certificate)
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
             },
-            Event::QuorumFormed(quorum_data) => {
-                self.handle_quorum_formed(quorum_data)
-                    .await
-                    .map_err(|err| TheaterError::Other(err.to_string()))?;
-                // TODO: Replace above with call to self.handle_quorum_formed().
+            Event::QuorumFormed => {
+                self.handle_quorum_formed().await.map_err(|err| {
+                    TheaterError::Other(err.to_string())
+                })?;
             },
             Event::QuorumMembersReceived(quorum_members) => self
                 .state_driver

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -55,7 +55,8 @@ impl Handler<EventMessage> for NodeRuntime {
                 }
             },
             Event::QuorumMembershipAssigmentCreated(assigned_membership) => {
-                let assignments = self.handle_quorum_membership_assigment_created(assigned_membership.clone());
+                let assignments =
+                    self.handle_quorum_membership_assigment_created(assigned_membership.clone());
 
                 let (part, node_id) =
                     self.generate_partial_commitment_message().map_err(|err| {
@@ -264,13 +265,14 @@ impl Handler<EventMessage> for NodeRuntime {
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
             },
             Event::QuorumFormed(quorum_data) => {
-                self.handle_quorum_formed(quorum_data).await.map_err(|err| {
-                    TheaterError::Other(err.to_string())
-                })?;
+                self.handle_quorum_formed(quorum_data)
+                    .await
+                    .map_err(|err| TheaterError::Other(err.to_string()))?;
                 // TODO: Replace above with call to self.handle_quorum_formed().
             },
             Event::QuorumMembersReceived(quorum_members) => self
-                .state_driver.handle_quorum_members_received(quorum_members),
+                .state_driver
+                .handle_quorum_members_received(quorum_members),
             // Event::ElectedMiner((_winner_claim_hash, winner_claim)) => {
             //     if self.miner.check_claim(winner_claim.hash) {
             //         let mining_result = self.miner.try_mine();
@@ -320,15 +322,21 @@ impl Handler<EventMessage> for NodeRuntime {
             Event::TxnAddedToMempool(txn_hash) => {
                 if let Ok(votes) = self.validate_mempool(1) {
                     self.events_tx
-                        .send(Event::TransactionsValidated { 
-                            votes, 
-                            quorum_threshold: self.config.threshold_config.threshold as usize
-                        }.into())
+                        .send(
+                            Event::TransactionsValidated {
+                                votes,
+                                quorum_threshold: self.config.threshold_config.threshold as usize,
+                            }
+                            .into(),
+                        )
                         .await
                         .map_err(|err| TheaterError::Other(err.to_string()))?;
                 }
             },
-            Event::TransactionsValidated { votes, quorum_threshold } => {
+            Event::TransactionsValidated {
+                votes,
+                quorum_threshold,
+            } => {
                 // TODO: Send Votes to Harvester Nodes
             },
             Event::NoOp => {},

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -264,11 +264,7 @@ impl Handler<EventMessage> for NodeRuntime {
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
             },
             Event::QuorumFormed(quorum_data) => {
-                self.events_tx.send(
-                    Event::QuorumFormed(
-                        quorum_data
-                    ).into()
-                ).await.map_err(|err| {
+                self.handle_quorum_formed(quorum_data).await.map_err(|err| {
                     TheaterError::Other(err.to_string())
                 })?;
                 // TODO: Replace above with call to self.handle_quorum_formed().

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -55,7 +55,7 @@ impl Handler<EventMessage> for NodeRuntime {
                 }
             },
             Event::QuorumMembershipAssigmentCreated(assigned_membership) => {
-                self.handle_quorum_membership_assigment_created(assigned_membership.clone());
+                let assignments = self.handle_quorum_membership_assigment_created(assigned_membership.clone());
 
                 let (part, node_id) =
                     self.generate_partial_commitment_message().map_err(|err| {

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -265,10 +265,10 @@ impl Handler<EventMessage> for NodeRuntime {
                 self.handle_block_certificate_created(certificate)
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
             },
-            Event::HarvesterPublicKeyReceived(public_key_set) => self
-                .state_driver
-                .handle_harvester_public_key_received(public_key_set),
-
+//            Event::HarvesterPublicKeyReceived(public_key_set) => self
+//               .handle_harvester_public_key_received(public_key_set),
+            Event::QuorumMembersReceived(quorum_members) => self
+                .state_driver.handle_quorum_members_received(quorum_members),
             // Event::ElectedMiner((_winner_claim_hash, winner_claim)) => {
             //     if self.miner.check_claim(winner_claim.hash) {
             //         let mining_result = self.miner.try_mine();

--- a/crates/node/src/state_manager/manager.rs
+++ b/crates/node/src/state_manager/manager.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use block::{Block, BlockHash, Certificate, ClaimHash, ProposalBlock};
+use block::{Block, BlockHash, Certificate, ClaimHash, ProposalBlock, QuorumMembers};
 use bulldag::{graph::BullDag, vertex::Vertex};
 use ethereum_types::U256;
 use events::{Event, EventMessage, EventPublisher, Vote};
@@ -375,8 +375,8 @@ impl StateManager {
         Ok(())
     }
 
-    pub fn handle_harvester_public_key_received(&mut self, public_key_set: PublicKeySet) {
-        self.dag.set_harvester_pubkeys(public_key_set)
+    pub fn handle_quorum_members_received(&mut self, quorum_members: QuorumMembers) {
+        self.dag.set_quorum_members(quorum_members)
     }
 
     pub fn get_claims(&self, claim_hashes: Vec<ClaimHash>) -> Result<Claims> {

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -575,6 +575,8 @@ pub async fn create_test_network(n: u16) -> Vec<Node> {
 
     let node_0 = Node::start(config).await.unwrap();
 
+    dbg!("{}", &node_0);
+
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
     let mut bootstrap_node_config = vrrb_config::BootstrapConfig {

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -13,3 +13,5 @@ secp256k1 = { workspace = true }
 serde_json = { workspace = true }
 jsonrpsee = { workspace = true }
 kademlia-dht = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }

--- a/crates/primitives/src/base.rs
+++ b/crates/primitives/src/base.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
+use hbbft::crypto::PublicKeySet;
+use hex;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// The unit of time within VRRB.
 /// It lasts for some number
@@ -68,7 +71,6 @@ pub type QuorumSize = usize;
 pub type QuorumThreshold = usize;
 pub type FarmerQuorumThreshold = usize;
 pub type HarvesterQuorumThreshold = usize;
-pub type QuorumId = String;
 pub type QuorumPubKey = String;
 
 pub type NodeTypeBytes = ByteVec;
@@ -92,5 +94,21 @@ impl Display for QuorumKind {
             QuorumKind::Farmer => write!(f, "Farmer"),
             QuorumKind::Miner => write!(f, "Miner"),
         }
+    }
+}
+
+/// A hashed [PublicKeySet].
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct QuorumId(String);
+impl QuorumId {
+    pub fn new(s: PublicKeySet) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(s.public_key().to_bytes());
+        let result = hasher.finalize();
+
+        Self(hex::encode(result))
+    }
+    pub fn get_inner(&self) -> String {
+        self.0.clone()
     }
 }

--- a/crates/primitives/src/base.rs
+++ b/crates/primitives/src/base.rs
@@ -68,6 +68,8 @@ pub type QuorumSize = usize;
 pub type QuorumThreshold = usize;
 pub type FarmerQuorumThreshold = usize;
 pub type HarvesterQuorumThreshold = usize;
+pub type QuorumId = String;
+pub type QuorumPubKey = String;
 
 pub type NodeTypeBytes = ByteVec;
 pub type QuorumPublicKey = ByteVec;

--- a/crates/vrrb_config/src/bootstrap_quorum.rs
+++ b/crates/vrrb_config/src/bootstrap_quorum.rs
@@ -20,8 +20,6 @@ pub type QuorumMembers = BTreeMap<NodeId, QuorumMember>;
 pub struct QuorumMembershipConfig {
     pub quorum_kind: QuorumKind,
     pub quorum_members: BTreeMap<NodeId, QuorumMember>,
-    // TODO: This might be the place to put quorum info:q
-    //
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
This PR modifies the consensus module, it adds some new methods, a few for checking node quorum membership and node quorum type, it adds `current_quorum_member` field and `current_quorums_pubkeys` field, and then also adds a field to maintain the local nodes quorum membership and the local nodes quorum type for easy checking and to ensure the local node doesn't consume resources that it is not intended to consume. We also modify the votes_pool field on the `ConsensusModule` struct to make it more efficient when handling votes and to ensure that the same vote cannot be cast twice for the same transaction.

TODO: Ensure that a vote from the current node is not in the Votes set before adding it. Minor changes to the vote, such as changing from `true` to `false` on the `is_txn_valid` field in the `Vote` struct could lead to multiple votes from the same node being included in the set.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `hash()` method to the `Block` struct for variant-based hash value retrieval.
- Refactor: Replaced `NodeIdx` with `NodeId` type in various places for better clarity and consistency.
- New Feature: Added two new variants to the `Event` enum - `TransactionValidated` and `TransactionsValidated` for more granular transaction validation events.
- Refactor: Modified the `Vote` struct by changing the type of `farmer_id` and `farmer_node_id` from `Vec<u8>` to `NodeId` for improved data modeling.
- New Feature: Added a `len()` method to the `LeftRightMempool` struct to return the number of key-value pairs in the map.
- Refactor: Updated the `MinerConfig` struct, renaming `secret_key` and `public_key` fields to use specific types (`MinerSecretKey` and `MinerPublicKey`) for enhanced security.
- New Feature: Added several methods to the `ConsensusModule` struct for handling various events and updating internal state.
- Refactor: Made `elect_quorum` method in `QuorumModule` struct public for external access.
- Bug Fix: Added error handling to `NodeRuntime::new` function call to ensure proper error conversion.
- Test: Added tests for various scenarios including node runtime assignment, commitment generation, shared key generation, transaction validation, block proposal, and convergence block handling.
- Chore: Deprecated `handle_new_txn_created` function and replaced it with `insert_txn_to_mempool`.
- Style: Introduced a check in `apply_block` function to ensure that the genesis block contains at least one transaction.
- Refactor: Improved the validation logic and error handling in `TxnValidator` struct.
- New Feature: Implemented `Clone` trait for `ValidatorCoreManager`, allowing it to be cloned with its own independent thread pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->