### PR TITLE
Vrs 572 wallet cli with transaction kind

### DIFF
--- a/crates/cli/src/commands/wallet/transfer.rs
+++ b/crates/cli/src/commands/wallet/transfer.rs
@@ -1,6 +1,5 @@
 use primitives::Address;
-use vrrb_core::transactions::Token;
-use vrrb_rpc::rpc::api::RpcTransactionDigest;
+use vrrb_core::transactions::{RpcTransactionDigest, Token};
 use wallet::v2::Wallet;
 
 use crate::result::CliError;

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -319,7 +319,7 @@ impl From<Event> for messr::Message<Event> {
             Event::CreateAccountRequested(_)
             | Event::NewTxnCreated(_)
             | Event::TxnAddedToMempool(_) =>
-                messr::Message::new(Some("runtime-events".into()), evt),
+                messr::Message::new(Some(RUNTIME_TOPIC_STR.into()), evt),
             _ => messr::Message::new(None, evt),
         }
     }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -7,10 +7,7 @@ use block::{
 use ethereum_types::U256;
 use hbbft::sync_key_gen::Ack;
 use hbbft::{crypto::PublicKeySet, sync_key_gen::Part};
-use primitives::{
-    Address, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx, ProgramExecutionOutput,
-    PublicKeyShareVec, RawSignature, Round, Seed, TxnValidationStatus, ValidatorPublicKeyShare,
-};
+use primitives::{Address, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx, ProgramExecutionOutput, PublicKeyShareVec, RawSignature, Round, RUNTIME_TOPIC_STR, Seed, TxnValidationStatus, ValidatorPublicKeyShare};
 use serde::{Deserialize, Serialize};
 use vrrb_core::claim::Claim;
 use vrrb_core::transactions::{TransactionDigest, TransactionKind};

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -314,8 +314,12 @@ impl From<Event> for Vec<u8> {
 
 impl From<Event> for messr::Message<Event> {
     fn from(evt: Event) -> Self {
-        match evt {
+        match &evt {
             Event::Stop => messr::Message::stop_signal(None),
+            Event::CreateAccountRequested(_)
+            | Event::NewTxnCreated(_)
+            | Event::TxnAddedToMempool(_) =>
+                messr::Message::new(Some("runtime-events".into()), evt),
             _ => messr::Message::new(None, evt),
         }
     }

--- a/crates/node/src/network/handler.rs
+++ b/crates/node/src/network/handler.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use events::{Event, EventMessage};
 use telemetry::info;
 use theater::{ActorId, ActorLabel, ActorState, Handler, TheaterError};
+use primitives::RUNTIME_TOPIC_STR;
 
 use super::NetworkModule;
 
@@ -35,7 +36,7 @@ impl Handler<EventMessage> for NetworkModule {
                 );
 
                 let evt = Event::NodeAddedToPeerList(peer_data.clone());
-                let em = EventMessage::new(Some("runtime-events".into()), evt);
+                let em = EventMessage::new(Some(RUNTIME_TOPIC_STR.into()), evt);
 
                 self.events_tx
                     .send(em)

--- a/crates/node/src/network/network_event_handler.rs
+++ b/crates/node/src/network/network_event_handler.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use dyswarm::types::Message as DyswarmMessage;
 use events::{Event, EventMessage, EventPublisher, PeerData};
-use primitives::NodeId;
+use primitives::{NETWORK_TOPIC_STR, NodeId, RUNTIME_TOPIC_STR};
 
 use crate::{network::NetworkEvent, NodeError};
 
@@ -45,7 +45,7 @@ impl dyswarm::server::Handler<NetworkEvent> for DyswarmHandler {
                 // TODO: once all known peers have been joined, send a `NetworkReady` event so a
                 // dkg can be started and the first quorums can be formed
 
-                let em = EventMessage::new(Some("network-events".into()), evt);
+                let em = EventMessage::new(Some(NETWORK_TOPIC_STR.into()), evt);
 
                 self.events_tx.send(em).await.map_err(NodeError::from)?;
             },
@@ -58,7 +58,7 @@ impl dyswarm::server::Handler<NetworkEvent> for DyswarmHandler {
                 );
 
                 let evt = Event::ClaimReceived(claim);
-                let em = EventMessage::new(Some("network-events".into()), evt);
+                let em = EventMessage::new(Some(NETWORK_TOPIC_STR.into()), evt);
 
                 self.events_tx.send(em).await.map_err(NodeError::from)?;
             },
@@ -73,13 +73,13 @@ impl dyswarm::server::Handler<NetworkEvent> for DyswarmHandler {
                 );
 
                 let evt = Event::QuorumMembershipAssigmentCreated(assigned_membership);
-                let em = EventMessage::new(Some("runtime-events".into()), evt);
+                let em = EventMessage::new(Some(RUNTIME_TOPIC_STR.into()), evt);
 
                 self.events_tx.send(em).await.map_err(NodeError::from)?;
             },
             NetworkEvent::PartCommitmentCreated(node_id, part) => {
                 let evt = Event::PartCommitmentCreated(node_id, part);
-                let em = EventMessage::new(Some("runtime-events".into()), evt);
+                let em = EventMessage::new(Some(RUNTIME_TOPIC_STR.into()), evt);
 
                 if let Err(err) = self.events_tx.send(em).await {
                     telemetry::error!("{}", err);
@@ -96,7 +96,7 @@ impl dyswarm::server::Handler<NetworkEvent> for DyswarmHandler {
                     sender_id,
                     ack,
                 };
-                let em = EventMessage::new(Some("runtime-events".into()), evt);
+                let em = EventMessage::new(Some(RUNTIME_TOPIC_STR.into()), evt);
                 self.events_tx.send(em).await.map_err(NodeError::from)?;
             },
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use events::{Event, EventPublisher, EventRouter, Topic};
-use primitives::{KademliaPeerId, NodeType};
+use primitives::{JSON_RPC_API_TOPIC_STR, KademliaPeerId, NETWORK_TOPIC_STR, NodeType, RUNTIME_TOPIC_STR};
 use telemetry::info;
 use tokio::{
     sync::mpsc::{channel, UnboundedReceiver},
@@ -48,9 +48,9 @@ impl Node {
         let (events_tx, mut events_rx) = channel(events::DEFAULT_BUFFER);
 
         let mut router = EventRouter::new();
-        router.add_topic(Topic::from("json-rpc-api-control"), Some(1));
-        router.add_topic(Topic::from("network-events"), Some(1000));
-        router.add_topic(Topic::from("runtime-events"), Some(1000));
+        router.add_topic(Topic::from(JSON_RPC_API_TOPIC_STR), Some(1));
+        router.add_topic(Topic::from(NETWORK_TOPIC_STR), Some(1000));
+        router.add_topic(Topic::from(RUNTIME_TOPIC_STR), Some(1000));
 
         let cancel_token = CancellationToken::new();
         let cloned_token = cancel_token.clone();

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 use events::{Event, EventPublisher, EventRouter};
+use primitives::{JSON_RPC_API_TOPIC_STR, NETWORK_TOPIC_STR, RUNTIME_TOPIC_STR};
 use telemetry::info;
 use vrrb_config::NodeConfig;
 
@@ -29,9 +30,9 @@ pub async fn setup_runtime_components(
 ) -> Result<(RuntimeComponentManager, NodeConfig)> {
     let mut config = original_config.clone();
 
-    let runtime_events_rx = router.subscribe(Some("runtime-events".into()))?;
-    let network_events_rx = router.subscribe(Some("network-events".into()))?;
-    let jsonrpc_events_rx = router.subscribe(Some("json-rpc-api-control".into()))?;
+    let runtime_events_rx = router.subscribe(Some(RUNTIME_TOPIC_STR.into()))?;
+    let network_events_rx = router.subscribe(Some(NETWORK_TOPIC_STR.into()))?;
+    let jsonrpc_events_rx = router.subscribe(Some(JSON_RPC_API_TOPIC_STR.into()))?;
     let indexer_events_rx = router.subscribe(None)?;
 
     let mut runtime_manager = RuntimeComponentManager::new();

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -336,7 +336,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn bootstrap_node_runtime_can_produce_genesis_transaction() {
-        let (mut node_0, farmers, harvesters, miners) = setup_network(8).await;
+        let (node_0, farmers, harvesters, miners) = setup_network(8).await;
         node_0.produce_genesis_transactions().unwrap();
 
         for (_, node) in farmers.iter() {

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use dkg_engine::dkg::DkgGenerator;
 use events::{Event, EventMessage, EventPublisher, EventSubscriber, Vote};
-use primitives::{NodeId, NodeType, ValidatorPublicKey};
+use primitives::{NETWORK_TOPIC_STR, NodeId, NodeType, ValidatorPublicKey};
 use telemetry::info;
 use theater::{Actor, ActorId, ActorImpl, ActorLabel, ActorState, Handler, TheaterError};
 use vrrb_config::{QuorumMember, QuorumMembershipConfig};
@@ -46,7 +46,7 @@ impl Handler<EventMessage> for NodeRuntime {
                 if let Some(assignments) = assignments {
                     for (_, assigned_membership) in assignments {
                         let event = Event::QuorumMembershipAssigmentCreated(assigned_membership);
-                        let em = EventMessage::new(Some("network-events".into()), event);
+                        let em = EventMessage::new(Some(NETWORK_TOPIC_STR.into()), event);
                         self.events_tx
                             .send(em)
                             .await
@@ -66,7 +66,7 @@ impl Handler<EventMessage> for NodeRuntime {
 
                 let event = Event::PartCommitmentCreated(node_id, part);
 
-                let em = EventMessage::new(Some("network-events".into()), event);
+                let em = EventMessage::new(Some(NETWORK_TOPIC_STR.into()), event);
 
                 self.events_tx
                     .send(em)
@@ -86,7 +86,7 @@ impl Handler<EventMessage> for NodeRuntime {
                     ack,
                 };
 
-                let em = EventMessage::new(Some("network-events".into()), event);
+                let em = EventMessage::new(Some(NETWORK_TOPIC_STR.into()), event);
 
                 self.events_tx
                     .send(em)
@@ -119,7 +119,7 @@ impl Handler<EventMessage> for NodeRuntime {
 
                 let event = Event::MinerElected(winner);
 
-                let em = EventMessage::new(Some("network-events".into()), event);
+                let em = EventMessage::new(Some(NETWORK_TOPIC_STR.into()), event);
 
                 self.events_tx
                     .send(em)

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -38,13 +38,13 @@ impl Handler<EventMessage> for NodeRuntime {
     async fn handle(&mut self, event: EventMessage) -> theater::Result<ActorState> {
         match event.into() {
             Event::NodeAddedToPeerList(peer_data) => {
-                let assigments = self
+                let assignments = self
                     .handle_node_added_to_peer_list(peer_data.clone())
                     .await
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
-                if let Some(assigments) = assigments {
-                    for (_, assigned_membership) in assigments {
+                if let Some(assignments) = assignments {
+                    for (_, assigned_membership) in assignments {
                         let event = Event::QuorumMembershipAssigmentCreated(assigned_membership);
                         let em = EventMessage::new(Some("network-events".into()), event);
                         self.events_tx
@@ -75,7 +75,8 @@ impl Handler<EventMessage> for NodeRuntime {
             },
 
             Event::PartCommitmentCreated(node_id, part) => {
-                let (receiver_id, sender_id, ack) = self
+                //TODO: handle receiver_id and sender_id
+                let (_receiver_id, _sender_id, ack) = self
                     .handle_part_commitment_created(node_id.clone(), part)
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
@@ -237,8 +238,9 @@ impl Handler<EventMessage> for NodeRuntime {
                 self.state_driver.handle_transaction_validated(txn);
             },
 
-            Event::CreateAccountRequested((address, account_bytes)) => {
-                self.handle_create_account_requested(address.clone(), account_bytes);
+            Event::CreateAccountRequested((address, _account_bytes)) => {
+                //TODO: handle account_bytes
+                self.create_account(address.public_key()).expect("TODO: panic message");
             },
             Event::AccountUpdateRequested((_address, _account_bytes)) => {
                 //                if let Ok(account) =

--- a/crates/node/tests/state_sync.rs
+++ b/crates/node/tests/state_sync.rs
@@ -4,7 +4,7 @@ use node::{
 };
 use primitives::{generate_account_keypair, Address};
 use secp256k1::Message;
-use vrrb_core::transactions::NewTransferArgs;
+use vrrb_core::transactions::TransactionKind;
 use vrrb_rpc::rpc::{api::RpcApiClient, client::create_client};
 
 #[tokio::test]
@@ -32,18 +32,19 @@ async fn nodes_can_synchronize_state() {
 
         let signature =
             sk.sign_ecdsa(Message::from_hashed_data::<secp256k1::hashes::sha256::Hash>(b"vrrb"));
+
         client_1
-            .create_txn(NewTransferArgs {
-                timestamp: 0,
-                sender_address: Address::new(pk),
-                sender_public_key: pk,
-                receiver_address: Address::new(recv_pk),
-                token: None,
-                amount: 0,
-                signature,
-                nonce: 0,
-                validators: None,
-            })
+            .create_txn(
+                TransactionKind::transfer_builder()
+                    .timestamp(0)
+                    .sender_address(Address::new(pk))
+                    .sender_public_key(pk)
+                    .receiver_address(Address::new(recv_pk))
+                    .amount(0)
+                    .signature(signature)
+                    .nonce(0)
+                    .build_kind().expect("Unable to build transfer transaction")
+            )
             .await
             .unwrap();
     }

--- a/crates/primitives/src/base.rs
+++ b/crates/primitives/src/base.rs
@@ -29,6 +29,10 @@ pub const DEFAULT_CONNECTION_TIMEOUT_IN_SECS: u64 = 2;
 pub const RAPTOR_DECODER_CACHE_LIMIT: usize = 10000;
 pub const RAPTOR_DECODER_CACHE_TTL_IN_SECS: u64 = 1800000;
 
+pub const NETWORK_TOPIC_STR: &str = "network-events";
+pub const RUNTIME_TOPIC_STR: &str = "runtime-events";
+pub const JSON_RPC_API_TOPIC_STR: &str = "json-rpc-api-control";
+
 pub type ByteVec = Vec<u8>;
 pub type ByteSlice<'a> = &'a [u8];
 pub type ByteSlice32Bit = [u8; 32];

--- a/crates/vrrb_core/src/transactions/transaction.rs
+++ b/crates/vrrb_core/src/transactions/transaction.rs
@@ -131,10 +131,12 @@ impl QuorumCertifiedTxn
     }
 }
 
+pub type RpcTransactionDigest = String;
+
 #[derive(Debug, Default, Clone, Hash, Deserialize, Serialize, Eq, PartialEq)]
 pub struct TransactionDigest {
     inner: PrimitiveDigest,
-    digest_string: String,
+    digest_string: RpcTransactionDigest,
 }
 
 impl TransactionDigest {

--- a/crates/vrrb_rpc/src/rpc/api.rs
+++ b/crates/vrrb_rpc/src/rpc/api.rs
@@ -11,9 +11,7 @@ use vrrb_config::bootstrap_quorum::QuorumMembershipConfig;
 use vrrb_core::account::Account;
 use vrrb_core::claim::Claim;
 use vrrb_core::node_health_report::NodeHealthReport;
-use vrrb_core::transactions::{
-    NewTransferArgs, Token, Transaction, TransactionKind, TxAmount, TxNonce, TxTimestamp,
-};
+use vrrb_core::transactions::{NewTransferArgs, RpcTransactionDigest, Token, Transaction, TransactionKind, TxAmount, TxNonce, TxTimestamp};
 
 use crate::rpc::SignOpts;
 
@@ -32,8 +30,6 @@ pub struct FullMempoolSnapshotResponse {
     data: Vec<TransactionRecord>,
 }
 
-pub type RpcTransactionDigest = String;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcTransactionRecord {
     pub id: RpcTransactionDigest,
@@ -51,7 +47,7 @@ pub struct RpcTransactionRecord {
 impl From<TransactionKind> for RpcTransactionRecord {
     fn from(txn: TransactionKind) -> Self {
         Self {
-            id: txn.digest().to_string(),
+            id: txn.id().digest_string(),
             timestamp: txn.timestamp(),
             sender_address: txn.sender_address(),
             sender_public_key: txn.sender_public_key(),
@@ -82,7 +78,7 @@ pub trait RpcApi {
 
     /// Create a new transaction
     #[method(name = "createTxn")]
-    async fn create_txn(&self, args: NewTransferArgs) -> Result<RpcTransactionRecord, Error>;
+    async fn create_txn(&self, txn: TransactionKind) -> Result<RpcTransactionRecord, Error>;
 
     /// Get a transaction from state
     #[method(name = "getTransaction")]

--- a/crates/vrrb_rpc/src/rpc/api.rs
+++ b/crates/vrrb_rpc/src/rpc/api.rs
@@ -11,7 +11,7 @@ use vrrb_config::bootstrap_quorum::QuorumMembershipConfig;
 use vrrb_core::account::Account;
 use vrrb_core::claim::Claim;
 use vrrb_core::node_health_report::NodeHealthReport;
-use vrrb_core::transactions::{NewTransferArgs, RpcTransactionDigest, Token, Transaction, TransactionKind, TxAmount, TxNonce, TxTimestamp};
+use vrrb_core::transactions::{RpcTransactionDigest, Token, Transaction, TransactionKind, TxAmount, TxNonce, TxTimestamp};
 
 use crate::rpc::SignOpts;
 

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -14,16 +14,14 @@ use telemetry::{debug, error};
 use vrrb_config::bootstrap_quorum::QuorumMembershipConfig;
 use vrrb_core::claim::Claim;
 use vrrb_core::node_health_report::NodeHealthReport;
-use vrrb_core::transactions::{
-    NewTransferArgs, Transaction, TransactionDigest, TransactionKind, Transfer,
-};
+use vrrb_core::transactions::{NewTransferArgs, RpcTransactionDigest, Transaction, TransactionDigest, TransactionKind, Transfer};
 use vrrb_core::{account::Account, serde_helpers::encode_to_binary};
 
 use super::{
     api::{FullMempoolSnapshot, RpcApiServer},
     SignOpts,
 };
-use crate::rpc::api::{FullStateSnapshot, RpcTransactionDigest, RpcTransactionRecord};
+use crate::rpc::api::{FullStateSnapshot, RpcTransactionRecord};
 
 #[derive(Debug, Clone)]
 pub struct RpcServerImpl {
@@ -57,8 +55,7 @@ impl RpcApiServer for RpcServerImpl {
     }
 
     //TODO: this should either exist for every transaction type or allow creating multiple types
-    async fn create_txn(&self, args: NewTransferArgs) -> Result<RpcTransactionRecord, Error> {
-        let txn = TransactionKind::Transfer(Transfer::new(args));
+    async fn create_txn(&self, txn: TransactionKind) -> Result<RpcTransactionRecord, Error> {
         let event = Event::NewTxnCreated(txn.clone());
 
         debug!("{:?}", event);

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -14,7 +14,7 @@ use telemetry::{debug, error};
 use vrrb_config::bootstrap_quorum::QuorumMembershipConfig;
 use vrrb_core::claim::Claim;
 use vrrb_core::node_health_report::NodeHealthReport;
-use vrrb_core::transactions::{NewTransferArgs, RpcTransactionDigest, Transaction, TransactionDigest, TransactionKind, Transfer};
+use vrrb_core::transactions::{RpcTransactionDigest, Transaction, TransactionDigest, TransactionKind};
 use vrrb_core::{account::Account, serde_helpers::encode_to_binary};
 
 use super::{

--- a/crates/wallet/src/v2/mod.rs
+++ b/crates/wallet/src/v2/mod.rs
@@ -180,8 +180,7 @@ impl Wallet {
             .await
             .map_err(|err| {
                 error!("{:?}", err.to_string());
-
-                WalletError::Custom(format!("API Error: {err}"))
+                WalletError::Custom(format!("API Error: {}", err))
             })?;
 
         Ok(transfer.id().digest_string())

--- a/crates/wallet/src/v2/mod.rs
+++ b/crates/wallet/src/v2/mod.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 use telemetry::error;
 use thiserror::Error;
 use vrrb_core::account::Account;
-use vrrb_core::transactions::{NewTransferArgs, Token};
+use vrrb_core::transactions::{Transaction, TransactionKind, Token, RpcTransactionDigest};
 use vrrb_rpc::rpc::{
-    api::{RpcApiClient, RpcTransactionDigest, RpcTransactionRecord},
+    api::{RpcApiClient, RpcTransactionRecord},
     client::create_client,
 };
 
@@ -161,21 +161,21 @@ impl Wallet {
 
         let signature = self.sign_transaction(&payload[..]);
 
-        let txn_args = NewTransferArgs {
-            timestamp,
-            sender_address,
-            sender_public_key: self.public_key,
-            receiver_address: receiver,
-            token: Some(token),
-            amount,
-            signature,
-            validators: Some(HashMap::new()),
-            nonce: self.nonce,
-        };
+        let transfer = TransactionKind::transfer_builder()
+            .timestamp(timestamp)
+            .sender_address(sender_address)
+            .sender_public_key(self.public_key)
+            .receiver_address(receiver)
+            .token(token)
+            .amount(amount)
+            .signature(signature)
+            .validators(HashMap::new())
+            .nonce(self.nonce)
+            .build_kind().expect("failed to build transfer transaction");
 
         let txn = self
             .client
-            .create_txn(txn_args.clone())
+            .create_txn(transfer.clone())
             .await
             .map_err(|err| {
                 error!("{:?}", err.to_string());
@@ -183,7 +183,7 @@ impl Wallet {
                 WalletError::Custom(format!("API Error: {err}"))
             })?;
 
-        Ok(txn.id)
+        Ok(transfer.id().digest_string())
     }
 
     pub async fn get_transaction(

--- a/crates/wallet/src/v2/mod.rs
+++ b/crates/wallet/src/v2/mod.rs
@@ -171,9 +171,10 @@ impl Wallet {
             .signature(signature)
             .validators(HashMap::new())
             .nonce(self.nonce)
-            .build_kind().expect("failed to build transfer transaction");
+            .build_kind()
+            .map_err(|_| WalletError::Custom("Failed to build transfer transaction".to_string()))?;
 
-        let txn = self
+        self
             .client
             .create_txn(transfer.clone())
             .await

--- a/crates/wallet/tests/wallet_rpc_tests.rs
+++ b/crates/wallet/tests/wallet_rpc_tests.rs
@@ -37,15 +37,19 @@ pub async fn wallet_sends_txn_to_rpc_server() {
     let (events_tx, _events_rx) = channel(100);
 
     // Set up RPC Server to accept connection from client
-    let mut json_rpc_server_config = JsonRpcServerConfig::default();
-    json_rpc_server_config.events_tx = events_tx;
+    let json_rpc_server_config = JsonRpcServerConfig {
+        events_tx,
+        ..Default::default()
+    };
 
     let (handle, socket_addr) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();
 
     tokio::spawn(handle.stopped());
 
-    let mut wallet_config = WalletConfig::default();
-    wallet_config.rpc_server_address = socket_addr;
+    let wallet_config = WalletConfig {
+        rpc_server_address: socket_addr,
+        ..Default::default()
+    };
 
     let mut wallet = Wallet::new(wallet_config).await.unwrap();
 
@@ -65,7 +69,7 @@ pub async fn wallet_sends_txn_to_rpc_server() {
     let txn_digest = wallet
         .send_transaction(
             0,
-            Address::new(recv_pk.clone()),
+            Address::new(recv_pk),
             10,
             Token::default(),
             timestamp,
@@ -89,15 +93,19 @@ pub async fn wallet_sends_create_account_request_to_rpc_server() {
     let (events_tx, _events_rx) = channel(100);
 
     // Set up RPC Server to accept connection from client
-    let mut json_rpc_server_config = JsonRpcServerConfig::default();
-    json_rpc_server_config.events_tx = events_tx;
+    let json_rpc_server_config = JsonRpcServerConfig {
+        events_tx,
+        ..Default::default()
+    };
 
     let (handle, socket_addr) = JsonRpcServer::run(&json_rpc_server_config).await.unwrap();
 
     tokio::spawn(handle.stopped());
 
-    let mut wallet_config = WalletConfig::default();
-    wallet_config.rpc_server_address = socket_addr;
+    let wallet_config = WalletConfig {
+        rpc_server_address: socket_addr,
+        ..Default::default()
+    };
 
     let mut wallet = Wallet::new(wallet_config).await.unwrap();
 


### PR DESCRIPTION





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a new `TransactionKind` enum and associated builder pattern for creating different types of transactions, improving flexibility and readability.
- Refactor: Replaced hard-coded string literals with constants for event topics, enhancing code maintainability.
- Refactor: Updated the transaction creation process in tests to use the `TransactionKind::transfer_builder()` method, improving code readability and maintainability.
- Refactor: Modified the `bootstrap_node_runtime_can_produce_genesis_transaction` test function to reduce unnecessary mutability.
- Bug Fix: Added a check in the `apply_block` function to ensure that the genesis block contains at least one transaction.
- Refactor: Updated error handling in various parts of the codebase to improve robustness.
- New Feature: Added handling for new events related to quorum formation and transaction voting.
- Refactor: Updated the `DagModule` struct and its associated methods to handle changes in quorum membership and block confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->