### PR TITLE
Fix Enable/Disable Node Bootstrapping via Command Line

### DIFF
--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -61,7 +61,7 @@ pub struct RunOpts {
     #[clap(long, value_parser, default_value = DEFAULT_GRPC_ADDRESS)]
     pub grpc_server_address: SocketAddr,
 
-    #[clap(long, default_value = "false")]
+    #[clap(long)]
     pub bootstrap: bool,
 
     #[clap(long, value_parser)]


### PR DESCRIPTION
Bootstrapping of node now can be enabled or disabled by just passing/skipping --bootstrap at command line
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Removed the default value for the `bootstrap` field in the `RunOpts` struct in `node/run.rs`. This change requires explicit specification of the `bootstrap` field when using the CLI, enhancing clarity and reducing potential for misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->