### PR TITLE
fix misspelling of detached

### DIFF
--- a/crates/cli/src/commands/node/mod.rs
+++ b/crates/cli/src/commands/node/mod.rs
@@ -15,7 +15,7 @@ pub enum NodeCmd {
     /// Prints currrent node configuration
     Info,
 
-    /// Stops any node currrently running in dettached mode
+    /// Stops any node currrently running in detached mode
     Stop,
 }
 

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -24,7 +24,7 @@ const DEFAULT_RAPTORQ_GOSSIP_ADDRESS: &str = DEFAULT_OS_ASSIGNED_PORT_ADDRESS;
 pub struct RunOpts {
     /// Start node as a background process
     #[clap(short, long, action, default_value = "false")]
-    pub dettached: bool,
+    pub detached: bool,
 
     ///Shows debugging config information
     #[clap(long, action, default_value = "false")]
@@ -149,7 +149,7 @@ impl Default for RunOpts {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
 
         Self {
-            dettached: Default::default(),
+            detached: Default::default(),
             debug_config: Default::default(),
             id: Default::default(),
             idx: Default::default(),
@@ -192,7 +192,7 @@ impl RunOpts {
             .set_default("preload_mock_state", false)?
             .set_default("debug_config", false)?
             .set_default("bootstrap", false)?
-            .set_default("dettached", false)?
+            .set_default("detached", false)?
             .add_source(File::with_name(config_path))
             .build()?;
 
@@ -236,7 +236,7 @@ impl RunOpts {
         };
 
         Self {
-            dettached: other.dettached,
+            detached: other.detached,
             debug_config: other.debug_config,
             id: self.id.clone().or(other.id.clone()),
             idx: self.idx.or(other.idx),
@@ -290,8 +290,8 @@ pub async fn run(args: RunOpts) -> Result<()> {
         dbg!(&node_config);
     }
 
-    if args.dettached {
-        run_dettached(node_config).await
+    if args.detached {
+        run_detached(node_config).await
     } else {
         run_blocking(node_config).await
     }
@@ -319,8 +319,8 @@ async fn run_blocking(node_config: NodeConfig) -> Result<()> {
 }
 
 #[telemetry::instrument]
-async fn run_dettached(node_config: NodeConfig) -> Result<()> {
-    info!("running node in dettached mode");
+async fn run_detached(node_config: NodeConfig) -> Result<()> {
+    info!("running node in detached mode");
     // start child process, run node within it
     Ok(())
 }


### PR DESCRIPTION
I tried to run the node detached, but realized the options it was looking for was `--dettached`. This PR fixes the spelling.