### PR TITLE
Add `keygen` CLI command

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
-use crate::commands::{config::ConfigOpts, node::NodeOpts, wallet::WalletOpts};
+use crate::commands::{config::ConfigOpts, keygen::KeygenCmd, node::NodeOpts, wallet::WalletOpts};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None, arg_required_else_help(true))]
@@ -33,4 +33,7 @@ pub enum Commands {
 
     /// Interact with with accounts and objects on the network
     Wallet(WalletOpts),
+
+    /// Manage keypair creation
+    Keygen(KeygenCmd),
 }

--- a/crates/cli/src/commands/keygen/mod.rs
+++ b/crates/cli/src/commands/keygen/mod.rs
@@ -1,0 +1,52 @@
+use crate::result::{CliError, Result};
+use clap::Parser;
+use std::path::PathBuf;
+use telemetry::{info, warn};
+use vrrb_core::keypair::{read_keypair_file, write_keypair_file, Keypair};
+
+#[derive(Debug, Parser)]
+pub struct KeygenCmd {
+    /// Overwrite the existing keypair if it exists.
+    #[clap(long)]
+    force: bool,
+}
+
+pub fn exec(args: KeygenCmd) -> Result<()> {
+    keygen(args.force)?;
+    Ok(())
+}
+
+/// Attempts to read a keypair from file, and generates a new keypair
+/// if one does not exist at the expected path.
+pub fn keygen(overwrite: bool) -> Result<Keypair> {
+    let data_dir = vrrb_core::storage_utils::get_node_data_dir()?;
+    std::fs::create_dir_all(&data_dir)?;
+    let keypair_file_path = PathBuf::from(&data_dir).join("keypair");
+    match read_keypair_file(&keypair_file_path) {
+        Ok(keypair) => {
+            if overwrite {
+                info!("Found stale keypair file, overwriting with new keypair");
+                write_new_keypair(&keypair_file_path)
+            } else {
+                Ok(keypair)
+            }
+        },
+        Err(err) => {
+            warn!("Failed to read keypair file: {err}");
+            info!("Generating new keypair");
+            write_new_keypair(&keypair_file_path)
+        },
+    }
+}
+
+fn write_new_keypair(outfile: &PathBuf) -> Result<Keypair> {
+    let keypair = Keypair::random();
+    write_keypair_file(&keypair, outfile)
+        .map_err(|err| CliError::Other(format!("failed to write keypair file: {err}")))?;
+    info!(
+        "Successfully wrote new keypair to file. PublicKey: {}",
+        keypair.miner_public_key_owned()
+    );
+
+    Ok(keypair)
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod keygen;
 pub mod node;
 pub(crate) mod utils;
 pub mod wallet;
@@ -16,6 +17,7 @@ pub async fn exec(args: Args) -> Result<()> {
     match cmd {
         Some(Commands::Node(node_args)) => node::exec(*node_args).await,
         Some(Commands::Wallet(wallet_args)) => wallet::exec(wallet_args).await,
+        Some(Commands::Keygen(keygen_args)) => keygen::exec(keygen_args),
         None => Err(CliError::NoSubcommand),
         _ => Err(CliError::InvalidCommand(format!("{cmd:?}"))),
     }


### PR DESCRIPTION
Adds a key generator CLI command that will generate a new keypair and write it to file if it doesn't exist, or if `--force` is specified, otherwise leaving the existing keypair intact.

Closes #575 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a `Keygen` subcommand to the command-line interface for managing keypair creation. This feature simplifies the process of generating and managing keypairs.
- Refactor: Updated the `node/run` module to use the new `Keygen` command for keypair generation, enhancing the consistency of key management across the software.
- Usability: The `Keygen` command checks for an existing keypair file and generates a new one if none exists. It also includes an `overwrite` option for replacing the current keypair, providing users with more control over their key management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->