### PR TITLE
Update `keygen` CLI to print `PublicKey` to `stdout` without debug info

### DIFF
--- a/crates/cli/src/commands/keygen/mod.rs
+++ b/crates/cli/src/commands/keygen/mod.rs
@@ -12,7 +12,9 @@ pub struct KeygenCmd {
 }
 
 pub fn exec(args: KeygenCmd) -> Result<()> {
-    keygen(args.force)?;
+    let public_key = keygen(args.force)?.miner_public_key_owned();
+    println!("PublicKey:\n{public_key}");
+
     Ok(())
 }
 
@@ -28,6 +30,7 @@ pub fn keygen(overwrite: bool) -> Result<Keypair> {
                 info!("Found stale keypair file, overwriting with new keypair");
                 write_new_keypair(&keypair_file_path)
             } else {
+                info!("Found existing keypair");
                 Ok(keypair)
             }
         },
@@ -43,10 +46,7 @@ fn write_new_keypair(outfile: &PathBuf) -> Result<Keypair> {
     let keypair = Keypair::random();
     write_keypair_file(&keypair, outfile)
         .map_err(|err| CliError::Other(format!("failed to write keypair file: {err}")))?;
-    info!(
-        "Successfully wrote new keypair to file. PublicKey: {}",
-        keypair.miner_public_key_owned()
-    );
+    info!("Successfully wrote new keypair to file");
 
     Ok(keypair)
 }

--- a/crates/cli/src/commands/keygen/mod.rs
+++ b/crates/cli/src/commands/keygen/mod.rs
@@ -12,8 +12,10 @@ pub struct KeygenCmd {
 }
 
 pub fn exec(args: KeygenCmd) -> Result<()> {
-    let public_key = keygen(args.force)?.miner_public_key_owned();
-    println!("PublicKey:\n{public_key}");
+    println!(
+        "PublicKey: {}",
+        keygen(args.force)?.miner_public_key_owned()
+    );
 
     Ok(())
 }


### PR DESCRIPTION


Closes #592 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Enhanced the key generation process by providing immediate feedback to the user. Now, after generating a new keypair, the public key is displayed directly in the console.
- Improvement: Added a notification system to alert users when an existing keypair is detected during the key generation process. This helps users avoid unintentional overwrites.
- Change: For security reasons, the public key is no longer logged after writing the new keypair to a file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->