### PR TITLE
Fix clippy warnings for storage crate

### DIFF
--- a/crates/storage/vrrbdb/src/rocksdb_adapter.rs
+++ b/crates/storage/vrrbdb/src/rocksdb_adapter.rs
@@ -83,12 +83,10 @@ fn new_db_instance(
     let mut instance = rocksdb::DB::open_cf(&options, &path, cfs)
         .map_err(|err| StorageError::Other(err.to_string()))?;
 
-    if !column_family_exists {
-        if column_family != DEFAULT_COLUMN_FAMILY_NAME {
-            instance
-                .create_cf(column_family, &options)
-                .map_err(|err| StorageError::Other(err.to_string()))?;
-        }
+    if !column_family_exists && column_family != DEFAULT_COLUMN_FAMILY_NAME {
+        instance
+            .create_cf(column_family, &options)
+            .map_err(|err| StorageError::Other(err.to_string()))?;
     }
 
     Ok(instance)
@@ -264,7 +262,9 @@ impl TreeReader for RocksDbAdapter {
                 let node_key: NodeKey = bincode::deserialize(&boxed_key.into_vec())?;
                 let node_value: Node = bincode::deserialize(&boxed_value.into_vec())?;
                 if let Node::Leaf(leaf_node) = node_value {
-                    if key_and_node.is_none() || leaf_node.key_hash() > key_and_node.as_ref().unwrap().1.key_hash() {
+                    if key_and_node.is_none()
+                        || leaf_node.key_hash() > key_and_node.as_ref().unwrap().1.key_hash()
+                    {
                         key_and_node.replace((node_key.clone(), leaf_node.clone()));
                     }
                 }

--- a/crates/storage/vrrbdb/src/rocksdb_adapter.rs
+++ b/crates/storage/vrrbdb/src/rocksdb_adapter.rs
@@ -191,19 +191,14 @@ impl VersionedDatabase for RocksDbAdapter {
         let locked = self.data.read();
         let iter = locked.db.iterator(IteratorMode::Start);
         let mut map = HashMap::new();
-        for res in iter {
-            match res {
-                Ok((boxed_key, boxed_node)) => {
-                    let key_bytes = boxed_key.into_vec();
-                    let node_bytes = boxed_node.into_vec();
-                    if let Ok(node_key) = bincode::deserialize::<NodeKey>(&key_bytes) {
-                        if let Ok(node) = bincode::deserialize::<Node>(&node_bytes) {
-                            map.insert(node_key, node);
-                        }
-                    };
-                },
-                _ => {},
-            }
+        for (boxed_key, boxed_node) in iter.flatten() {
+            let key_bytes = boxed_key.into_vec();
+            let node_bytes = boxed_node.into_vec();
+            if let Ok(node_key) = bincode::deserialize::<NodeKey>(&key_bytes) {
+                if let Ok(node) = bincode::deserialize::<Node>(&node_bytes) {
+                    map.insert(node_key, node);
+                }
+            };
         }
 
         map.into_iter()
@@ -257,16 +252,14 @@ impl TreeReader for RocksDbAdapter {
         let mut key_and_node: Option<(NodeKey, LeafNode)> = None;
 
         let iter = locked.db.iterator(IteratorMode::Start);
-        for res in iter {
-            if let Ok((boxed_key, boxed_value)) = res {
-                let node_key: NodeKey = bincode::deserialize(&boxed_key.into_vec())?;
-                let node_value: Node = bincode::deserialize(&boxed_value.into_vec())?;
-                if let Node::Leaf(leaf_node) = node_value {
-                    if key_and_node.is_none()
-                        || leaf_node.key_hash() > key_and_node.as_ref().unwrap().1.key_hash()
-                    {
-                        key_and_node.replace((node_key.clone(), leaf_node.clone()));
-                    }
+        for (boxed_key, boxed_value) in iter.flatten() {
+            let node_key: NodeKey = bincode::deserialize(&boxed_key.into_vec())?;
+            let node_value: Node = bincode::deserialize(&boxed_value.into_vec())?;
+            if let Node::Leaf(leaf_node) = node_value {
+                if key_and_node.is_none()
+                    || leaf_node.key_hash() > key_and_node.as_ref().unwrap().1.key_hash()
+                {
+                    key_and_node.replace((node_key.clone(), leaf_node.clone()));
                 }
             }
         }

--- a/crates/storage/vrrbdb/src/transaction_store/mod.rs
+++ b/crates/storage/vrrbdb/src/transaction_store/mod.rs
@@ -57,14 +57,14 @@ impl TransactionStore {
     }
 
     pub fn insert(&mut self, txn: TransactionKind) -> Result<()> {
-        self.trie.insert(txn.digest(), txn);
+        self.trie.insert(txn.id(), txn);
         Ok(())
     }
 
     pub fn extend(&mut self, transactions: Vec<TransactionKind>) {
         let transactions = transactions
             .into_iter()
-            .map(|txn| (txn.digest(), Some(txn)))
+            .map(|txn| (txn.id(), Some(txn)))
             .collect();
 
         self.trie.extend(transactions)

--- a/crates/storage/vrrbdb/src/transaction_store/transaction_store_rh.rs
+++ b/crates/storage/vrrbdb/src/transaction_store/transaction_store_rh.rs
@@ -48,7 +48,7 @@ impl TransactionStoreReadHandle {
                 if let Ok((_, txn)) = item {
                     let txn = bincode::deserialize::<TransactionKind>(&txn).unwrap_or_default();
 
-                    return Some((txn.digest(), txn));
+                    return Some((txn.id(), txn));
                 }
                 None
             })

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -267,12 +267,6 @@ impl VrrbDb {
     ) -> Result<()> {
         match txn_kind {
             TransactionKind::Transfer(txn) => self.apply_transfer(read_handle, txn),
-            _ => {
-                telemetry::info!("unsupported transaction type: {:?}", txn_kind);
-                Err(StorageError::Other(
-                    "unsupported transaction type".to_string(),
-                ))
-            },
         }
     }
 

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
-use block::{convergence_block, Block, ConvergenceBlock, ProposalBlock};
+use block::{Block, ConvergenceBlock, ProposalBlock};
 use ethereum_types::U256;
 use patriecia::RootHash;
 use primitives::Address;
 use storage_utils::{Result, StorageError};
-use vrrb_core::transactions::{Transaction, TransactionDigest, TransactionKind, Transfer};
+use vrrb_core::transactions::{Transaction, TransactionKind, Transfer};
 use vrrb_core::{
     account::{Account, UpdateArgs},
     claim::Claim,
@@ -43,20 +43,18 @@ pub struct ApplyBlockResult {
 
 impl ApplyBlockResult {
     pub fn state_root_hash_str(&self) -> String {
-        let state_root_hash = self.state_root_hash.clone();
+        let state_root_hash = self.state_root_hash;
         // let transaction_root_hash = self.transaction_store.root_hash()?;
 
         // let txn_root_hash_hex = hex::encode(txn_root_hash.0);
-        let state_root_hash_hex = hex::encode(state_root_hash.0);
+        hex::encode(state_root_hash.0)
         // let claim_root_hash_hex = hex::encode(claim_root_hash.0);
-        state_root_hash_hex
     }
 
     pub fn transactions_root_hash_str(&self) -> String {
-        let txn_root_hash = self.transactions_root_hash.clone();
+        let txn_root_hash = self.transactions_root_hash;
 
-        let txn_root_hash_hex = hex::encode(txn_root_hash.0);
-        txn_root_hash_hex
+        hex::encode(txn_root_hash.0)
     }
 }
 
@@ -295,7 +293,7 @@ impl VrrbDb {
 
             let mut txns = block.txns.clone();
             txns.retain(|digest, _| txn_set.contains(digest));
-            for (digest, txn_kind) in txns {
+            for (_digest, txn_kind) in txns {
                 self.apply_txn(read_handle.clone(), txn_kind)?;
             }
         }

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use primitives::{Address, NodeId};
 use storage_utils::StorageError;
-use vrrb_core::transactions::{Transaction, TransactionDigest, TransactionKind};
+use vrrb_core::transactions::{TransactionDigest, TransactionKind};
 use vrrb_core::{account::Account, claim::Claim};
 
 use crate::result::Result;

--- a/crates/storage/vrrbdb/tests/test_transaction_store.rs
+++ b/crates/storage/vrrbdb/tests/test_transaction_store.rs
@@ -1,6 +1,5 @@
 use std::env;
 
-use patriecia::{KeyHash, Sha256};
 use serial_test::serial;
 use vrrbdb::{VrrbDb, VrrbDbConfig};
 mod common;


### PR DESCRIPTION

Ref #454 
Addresses clippy warnings & formats relative files in the `storage` crate.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Refactor: Simplified database operations in `rocksdb_adapter.rs` for better efficiency and readability.
- New Feature: Updated transaction identification in `transaction_store/mod.rs` and `transaction_store_rh.rs` to use transaction `id` instead of `digest`, enhancing the way transactions are stored and identified.
- Chore: Cleaned up unused imports in `vrrbdb.rs`, improving code cleanliness and maintainability.
- Test: Updated test dependencies in `test_transaction_store.rs`, potentially enhancing test coverage and reliability. 

Please note that these changes are primarily under-the-hood improvements and may not result in noticeable changes for end-users. However, they contribute to the overall performance, reliability, and maintainability of the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->