### PR TITLE
Fix clippy warnings in vrrb_core create

### DIFF
--- a/crates/vrrb_core/src/claim.rs
+++ b/crates/vrrb_core/src/claim.rs
@@ -376,7 +376,7 @@ impl Claim {
     }
 
     pub fn public_key_owned(&self) -> PublicKey {
-        self.public_key.clone()
+        self.public_key
     }
 
     pub fn address_owned(&self) -> Address {

--- a/crates/vrrb_core/src/keypair.rs
+++ b/crates/vrrb_core/src/keypair.rs
@@ -69,7 +69,7 @@ impl KeyPair {
         let (sk, pk) = secp.generate_keypair(&mut rng);
         KeyPair {
             // TODO: Consider renaming to simply sk and pk as this pair is not only used for mining
-            miner_kp: (sk.clone(), pk.clone()),
+            miner_kp: (sk, pk),
             validator_kp: (sk, pk),
         }
     }
@@ -108,7 +108,7 @@ impl KeyPair {
         let secp = Secp256k1::new();
         let pk = sk.public_key(&secp);
         KeyPair {
-            miner_kp: (sk.clone(), pk.clone()),
+            miner_kp: (sk, pk),
             validator_kp: (sk, pk),
         }
     }
@@ -271,7 +271,7 @@ impl KeyPair {
     }
 
     pub fn get_validator_secret_key_owned(&self) -> SecretKey {
-        self.validator_kp.0.clone()
+        self.validator_kp.0
     }
 
     /// It returns the public key of the validator.

--- a/crates/vrrb_core/src/keypair.rs
+++ b/crates/vrrb_core/src/keypair.rs
@@ -30,7 +30,7 @@ pub type PublicKeys = (MinerPublicKey, PublicKey);
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct KeyPair {
-    pub miner_kp: (MinerSk, MinerPk),
+    pub miner_kp: (MinerSecretKey, MinerPublicKey),
     pub validator_kp: (SecretKey, PublicKey),
 }
 
@@ -104,7 +104,7 @@ impl KeyPair {
     /// Returns:
     ///
     /// A KeyPair struct
-    pub fn new(sk: SecretKey, _miner_sk: MinerSk) -> Self {
+    pub fn new(sk: SecretKey, _miner_sk: MinerSecretKey) -> Self {
         let secp = Secp256k1::new();
         let pk = sk.public_key(&secp);
         KeyPair {
@@ -116,7 +116,7 @@ impl KeyPair {
     /// Returns this `Keypair` as a byte array
     pub fn from_bytes(validator_key_bytes: &[u8], miner_key_bytes: &[u8]) -> Result<KeyPair> {
         let result = bincode::deserialize::<SerdeSecret<SecretKey>>(validator_key_bytes);
-        let miner_sk = if let Ok(miner_sk) = MinerSk::from_slice(miner_key_bytes) {
+        let miner_sk = if let Ok(miner_sk) = MinerSecretKey::from_slice(miner_key_bytes) {
             miner_sk
         } else {
             return Err(KeyPairError::InvalidKeyPair);
@@ -138,8 +138,8 @@ impl KeyPair {
     }
 
     /// Returns this Miner `PublicKey` from byte array `key_bytes`.
-    pub fn from_miner_pk_bytes(key_bytes: &[u8]) -> Result<MinerPk> {
-        match MinerPk::from_slice(key_bytes) {
+    pub fn from_miner_pk_bytes(key_bytes: &[u8]) -> Result<MinerPublicKey> {
+        match MinerPublicKey::from_slice(key_bytes) {
             Ok(public_key) => Ok(public_key),
             Err(_) => Err(KeyPairError::InvalidPublicKey),
         }
@@ -165,13 +165,13 @@ impl KeyPair {
     }
 
     /// Gets this `Keypair`'s SecretKey
-    pub fn get_secret_keys(&self) -> (&SecretKey, &MinerSk) {
+    pub fn get_secret_keys(&self) -> (&SecretKey, &MinerSecretKey) {
         (&self.validator_kp.0, &self.miner_kp.0)
     }
 
     /// > This function returns a tuple of references to the public keys of the
     /// > validator and miner
-    pub fn get_public_keys(&self) -> (&PublicKey, &MinerPk) {
+    pub fn get_public_keys(&self) -> (&PublicKey, &MinerPublicKey) {
         (&self.validator_kp.1, &self.miner_kp.1)
     }
 
@@ -238,9 +238,9 @@ impl KeyPair {
     /// Returns:
     ///
     /// The public key of the miner.
-    pub fn get_miner_public_key_from_secret_key(key: MinerSk) -> MinerPk {
+    pub fn get_miner_public_key_from_secret_key(key: MinerSecretKey) -> MinerPublicKey {
         let secp = Secp256k1::new();
-        MinerPk::from_secret_key(&secp, &key)
+        MinerPublicKey::from_secret_key(&secp, &key)
     }
 
     /// It returns the miner secret key.
@@ -248,7 +248,7 @@ impl KeyPair {
     /// Returns:
     ///
     /// The miner secret key.
-    pub fn get_miner_secret_key(&self) -> &MinerSk {
+    pub fn get_miner_secret_key(&self) -> &MinerSecretKey {
         &self.miner_kp.0
     }
 
@@ -257,7 +257,7 @@ impl KeyPair {
     /// Returns:
     ///
     /// The public key of the miner.
-    pub fn get_miner_public_key(&self) -> &MinerPk {
+    pub fn get_miner_public_key(&self) -> &MinerPublicKey {
         &self.miner_kp.1
     }
 

--- a/crates/vrrb_core/src/staking.rs
+++ b/crates/vrrb_core/src/staking.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use utils::hash_data;
 
-use crate::keypair::{MinerPk, MinerSk};
+use crate::keypair::{MinerPublicKey, MinerSecretKey};
 
 /// Represents a byte array that can be converted into a
 /// ThresholdSignature
@@ -80,7 +80,7 @@ pub enum StakeUpdate {
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Stake {
-    pubkey: MinerPk,
+    pubkey: MinerPublicKey,
     from: Address,
     to: Option<Address>,
     amount: StakeUpdate,
@@ -117,8 +117,8 @@ impl Stake {
     /// ```
     pub fn new(
         amount: StakeUpdate,
-        sk: MinerSk,
-        pk: MinerPk,
+        sk: MinerSecretKey,
+        pk: MinerPublicKey,
         from: Address,
         to: Option<Address>,
     ) -> Option<Self> {
@@ -156,7 +156,7 @@ impl Stake {
 
     /// returns the Stake public key which is used to verify
     /// the signature of the Stake transaction
-    pub fn get_pubkey(&self) -> MinerPk {
+    pub fn get_pubkey(&self) -> MinerPublicKey {
         self.pubkey
     }
 

--- a/crates/vrrb_core/src/transactions/transaction_kind.rs
+++ b/crates/vrrb_core/src/transactions/transaction_kind.rs
@@ -1,8 +1,10 @@
-use std::collections::HashMap;
-use serde::{Deserialize, Serialize};
+use crate::transactions::{
+    Token, Transaction, TransactionDigest, Transfer, TransferBuilder, TxAmount, TxNonce,
+    TxTimestamp,
+};
 use primitives::{Address, PublicKey, SecretKey, Signature};
-use crate::transactions::{Token, Transaction, TransactionDigest, Transfer, TransferBuilder, TxAmount, TxNonce, TxTimestamp};
-
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Hash, Debug, Deserialize, Clone, Serialize, Eq, PartialEq)]
 pub enum TransactionKind {
@@ -108,7 +110,7 @@ impl Transaction for TransactionKind {
 
     fn digest(&self) -> TransactionDigest {
         match self {
-            TransactionKind::Transfer(transfer) => transfer.digest(),
+            TransactionKind::Transfer(transfer) => transfer.id(),
         }
     }
 

--- a/crates/vrrb_core/src/transactions/transfer.rs
+++ b/crates/vrrb_core/src/transactions/transfer.rs
@@ -1,15 +1,11 @@
 use std::{
-    cmp::{Ord, Ordering, PartialOrd},
     collections::HashMap,
-    fmt::{self, Display, Formatter},
+    fmt,
     hash::{Hash, Hasher},
     str::FromStr,
 };
 
-use primitives::{
-    Address, ByteSlice, ByteVec, Digest as PrimitiveDigest, NodeIdx, PublicKey, RawSignature,
-    SecretKey,
-};
+use primitives::{Address, ByteSlice, ByteVec, PublicKey, SecretKey};
 use secp256k1::{ecdsa::Signature, Message};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -18,7 +14,6 @@ use utils::hash_data;
 use crate::transactions::transaction::Transaction;
 use crate::transactions::{Token, TransactionDigest, TransactionKind, BASE_FEE};
 use crate::{
-    helpers::gen_hex_encoded_string,
     keypair::Keypair,
     serde_helpers::{
         decode_from_binary_byte_slice, decode_from_json_byte_slice, encode_to_binary,

--- a/crates/vrrb_core/src/transactions/transfer.rs
+++ b/crates/vrrb_core/src/transactions/transfer.rs
@@ -88,7 +88,6 @@ pub struct TransferBuilder {
 }
 
 impl TransferBuilder {
-
     pub fn timestamp(mut self, timestamp: TxTimestamp) -> Self {
         self.timestamp = Some(timestamp);
         self
@@ -137,9 +136,16 @@ impl TransferBuilder {
     pub fn build(self) -> Result<Transfer, &'static str> {
         let id = generate_transfer_digest_vec(
             self.timestamp.ok_or("timestamp is missing")?,
-            self.sender_address.clone().ok_or("sender_address is missing")?.to_string(),
-            self.sender_public_key.ok_or("sender_public_key is missing")?,
-            self.receiver_address.clone().ok_or("receiver_address is missing")?.to_string(),
+            self.sender_address
+                .clone()
+                .ok_or("sender_address is missing")?
+                .to_string(),
+            self.sender_public_key
+                .ok_or("sender_public_key is missing")?,
+            self.receiver_address
+                .clone()
+                .ok_or("receiver_address is missing")?
+                .to_string(),
             self.token.clone().unwrap_or_default(),
             self.amount.ok_or("amount is missing")?,
             self.nonce.ok_or("nonce is missing")?,
@@ -193,13 +199,13 @@ impl Transfer {
         let token = args.token.clone().unwrap_or_default();
 
         let digest_vec = generate_transfer_digest_vec(
-            args.timestamp.clone(),
+            args.timestamp,
             args.sender_address.to_string(),
             args.sender_public_key,
             args.receiver_address.to_string(),
             token.clone(),
-            args.amount.clone(),
-            args.nonce.clone(),
+            args.amount,
+            args.nonce,
         );
 
         let digest = TransactionDigest::from(digest_vec);
@@ -421,8 +427,11 @@ impl FromStr for Transfer {
     type Err = TransferTransactionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str::<Transfer>(s)
-            .map_err(|err| TransferTransactionError::InvalidTransferTransaction(format!("failed to parse &str into Txn: {err}")))
+        serde_json::from_str::<Transfer>(s).map_err(|err| {
+            TransferTransactionError::InvalidTransferTransaction(format!(
+                "failed to parse &str into Txn: {err}"
+            ))
+        })
     }
 }
 


### PR DESCRIPTION
Ref https://github.com/versatus/versatus/issues/454
Addresses clippy warnings & formats relative files in the `vrrb_core` crate.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Refactor: Improved performance by eliminating unnecessary cloning operations in the `Claim` module.
- Refactor: Renamed `MinerSk` and `MinerPk` types to `MinerSecretKey` and `MinerPublicKey` respectively for better clarity in the `KeyPair` and `Staking` modules.
- Refactor: Updated `TransactionKind::Transfer` variant to call the `id()` method for better efficiency.
- Style: Cleaned up the `Transfer` module by removing unused imports, dependencies, and functions, and improved error handling.
- Performance: Reduced memory usage by replacing some `clone()` calls with direct value access in the `Transfer` module. 

These changes enhance the software's readability, efficiency, and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->