### PR TITLE
Fix clippy warnings for consensus crate

### DIFF
--- a/crates/consensus/quorum/src/lib.rs
+++ b/crates/consensus/quorum/src/lib.rs
@@ -326,8 +326,8 @@ mod tests {
             if let Ok(seed2) = Quorum::generate_seed(payload.clone(), keypair.clone()) {
                 if let Ok(mut quorum1) = Quorum::new(seed1, 11, None) {
                     if let Ok(mut quorum2) = Quorum::new(seed2, 11, None) {
-                        if let Ok(q1) = quorum1.run_election(dummy_claims1) {
-                            if let Ok(q2) = quorum2.run_election(dummy_claims2) {
+                        if let Ok(_q1) = quorum1.run_election(dummy_claims1) {
+                            if let Ok(_q2) = quorum2.run_election(dummy_claims2) {
                                 // TODO
                                 // assert!(q1.master_pubkeys == q2.master_pubkeys);
                             }

--- a/crates/consensus/quorum/src/quorum.rs
+++ b/crates/consensus/quorum/src/quorum.rs
@@ -173,7 +173,7 @@ impl Quorum {
 
         let members: Vec<(NodeId, PublicKey)> = election_results
             .values()
-            .map(|claim| (claim.node_id().clone(), claim.public_key.clone()))
+            .map(|claim| (claim.node_id().clone(), claim.public_key))
             .collect();
 
         let final_pubkeys = Vec::from_iter(members[0..num_claims].iter().cloned());

--- a/crates/consensus/reward/src/reward.rs
+++ b/crates/consensus/reward/src/reward.rs
@@ -94,15 +94,6 @@ impl Reward {
         self.amount = BASELINE_REWARD;
     }
 
-    /// The function `new_epoch` is called when a new epoch is reached. It
-    /// increments the epoch number, calculates the next epoch block, and
-    /// adjusts the block reward
-    ///
-    /// Arguments:
-    ///
-    /// * `adjustment_to_next_epoch`: The amount of adjustment to the next
-    ///   epoch.
-
     #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         serde_json::to_string(self).unwrap()

--- a/crates/consensus/reward/src/reward.rs
+++ b/crates/consensus/reward/src/reward.rs
@@ -89,11 +89,6 @@ impl Reward {
         }
     }
 
-    #[deprecated(note = "replaced by generate_next_reward method")]
-    pub fn update(&mut self, adjustment_to_next_epoch: i128) {
-        self.new_epoch(adjustment_to_next_epoch);
-    }
-
     /// This function resets the amount of reward to the baseline reward
     pub fn reset(&mut self) {
         self.amount = BASELINE_REWARD;
@@ -107,24 +102,6 @@ impl Reward {
     ///
     /// * `adjustment_to_next_epoch`: The amount of adjustment to the next
     ///   epoch.
-    #[deprecated(note = "deprecated as a result of self.update() method being deprecated")]
-    pub fn new_epoch(&mut self, adjustment_to_next_epoch: i128) {
-        self.epoch += 1;
-
-        // Next nth Block for epoch to end
-        self.next_epoch_block += NUMBER_OF_BLOCKS_PER_EPOCH;
-
-        //Adjust Block Reward
-        let amount =
-            self.amount as i128 + adjustment_to_next_epoch / NUMBER_OF_BLOCKS_PER_EPOCH as i128;
-        if amount <= 0 {
-            self.amount = MIN_BASELINE_REWARD;
-        } else if amount >= MAX_BASELINE_REWARD as i128 {
-            self.amount = MAX_BASELINE_REWARD;
-        } else {
-            self.amount = amount as u128;
-        }
-    }
 
     #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
@@ -205,15 +182,15 @@ mod tests {
 
     #[test]
     fn test_reward_state_after_next_epoch() {
-        let mut reward = Reward::genesis(Some("MINER_1".to_string()));
-        reward.new_epoch(15);
+        let reward = Reward::genesis(Some("MINER_1".to_string()));
+        reward.generate_next_reward(15);
         assert!(reward.amount >= MIN_BASELINE_REWARD && reward.amount <= MAX_BASELINE_REWARD);
     }
 
     #[test]
     fn test_restored_reward_state() {
         let mut reward = Reward::genesis(Some("MINER".to_string()));
-        reward.new_epoch(15);
+        reward.generate_next_reward(15);
         assert!(reward.amount >= MIN_BASELINE_REWARD && reward.amount <= MAX_BASELINE_REWARD);
         assert!(reward.valid_reward());
         reward.reset();

--- a/crates/consensus/signer/src/engine.rs
+++ b/crates/consensus/signer/src/engine.rs
@@ -50,7 +50,7 @@ impl QuorumMembers {
     pub fn get_public_key_from_members(&self, k: &NodeId) -> Option<PublicKey> {
         for (_, quorum_data) in self.0.iter() {
             if let Some(pub_key) = quorum_data.members.get(k) {
-                return Some(pub_key.clone());
+                return Some(*pub_key);
             }
         }
         None
@@ -58,12 +58,11 @@ impl QuorumMembers {
 
     pub fn get_harvester_data(&self) -> Option<QuorumData> {
         for (_, quorum_data) in self.0.iter() {
-            match &quorum_data.quorum_kind {
-                QuorumKind::Harvester => return Some(quorum_data.clone()),
-                _ => {},
+            if quorum_data.quorum_kind == QuorumKind::Harvester {
+                return Some(quorum_data.clone());
             }
         }
-        return None;
+        None
     }
 
     pub fn get_harvester_threshold(&self) -> usize {
@@ -99,7 +98,7 @@ impl QuorumMembers {
             }
         }
 
-        return Err(Error::IsNotFarmer);
+        Err(Error::IsNotFarmer)
     }
 
     pub fn is_harvester_quorum_member(
@@ -113,7 +112,7 @@ impl QuorumMembers {
             }
         }
 
-        return Err(Error::IsNotHarvester);
+        Err(Error::IsNotHarvester)
     }
 }
 
@@ -184,7 +183,7 @@ impl SignerEngine {
 
     pub fn verify_batch<T: AsRef<[u8]> + std::fmt::Debug>(
         &self,
-        batch_sigs: &Vec<(NodeId, Signature)>,
+        batch_sigs: &[(NodeId, Signature)],
         data: &T,
     ) -> Result<(), Error> {
         let errs = batch_sigs
@@ -209,7 +208,7 @@ impl SignerEngine {
     }
 
     pub fn public_key(&self) -> PublicKey {
-        self.local_node_public_key.clone()
+        self.local_node_public_key
     }
 
     pub fn set_quorum_members(&mut self, quorums: Vec<(QuorumKind, Vec<(NodeId, PublicKey)>)>) {

--- a/crates/consensus/signer/src/engine.rs
+++ b/crates/consensus/signer/src/engine.rs
@@ -181,9 +181,10 @@ impl SignerEngine {
         Err(Error::FailedVerification("missing public key".to_string()))
     }
 
+    #[allow(clippy::ptr_arg)]
     pub fn verify_batch<T: AsRef<[u8]> + std::fmt::Debug>(
         &self,
-        batch_sigs: &[(NodeId, Signature)],
+        batch_sigs: &Vec<(NodeId, Signature)>,
         data: &T,
     ) -> Result<(), Error> {
         let errs = batch_sigs

--- a/crates/consensus/signer/src/signer.rs
+++ b/crates/consensus/signer/src/signer.rs
@@ -35,7 +35,9 @@ pub trait Signer {
     ) -> SignerResult<bool>;
 }
 
-// TODO: make this cleaner if possible
+// TODO: make this cleaner if possible.
+// TODO: _fr_slot is not being used;
+// fr_repr will likely need to be mutable once it is being used.
 /// Converts a string slice into the Fr type.
 pub trait NodeIdFrBuilder: AsRef<str> {
     fn create_fr(&self) -> Fr {

--- a/crates/consensus/signer/src/signer.rs
+++ b/crates/consensus/signer/src/signer.rs
@@ -39,13 +39,13 @@ pub trait Signer {
 /// Converts a string slice into the Fr type.
 pub trait NodeIdFrBuilder: AsRef<str> {
     fn create_fr(&self) -> Fr {
-        let (m, l) = uuid::Uuid::from_str(&self.as_ref())
+        let (m, l) = uuid::Uuid::from_str(self.as_ref())
             .expect("failed to create uuid from string slice")
             .as_u64_pair();
-        let uuid_vec = vec![m, l, 0, 0];
-        let mut fr_repr = FrRepr::default();
-        for (mut fr_slot, uuid_slot) in fr_repr.0.iter().zip(uuid_vec.iter()) {
-            fr_slot = uuid_slot;
+        let uuid_vec = [m, l, 0, 0];
+        let fr_repr = FrRepr::default();
+        for (mut _fr_slot, uuid_slot) in fr_repr.0.iter().zip(uuid_vec.iter()) {
+            _fr_slot = uuid_slot;
         }
         Fr::from_repr(fr_repr).expect("failed to create Fr from FrRepr")
     }


### PR DESCRIPTION
Ref #454 
Addresses clippy warnings, and formats relevant files in the `consensus` crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Refactor: Improved the performance of the `Quorum` struct by optimizing the cloning process in the `map` function.
- New Feature: Introduced a `generate_next_reward` function in the `Reward` struct, enhancing the reward calculation process based on the current epoch and adjustments.
- Refactor: Updated the `get_public_key_from_members`, `get_harvester_data`, `is_farmer_quorum_member`, `is_harvester_quorum_member`, `verify_batch`, `public_key`, and `set_quorum_members` functions in the `engine.rs` file for better error handling and performance.
- Refactor: Optimized the `create_fr` method in the `NodeIdFrBuilder` trait by replacing the usage of a `Vec` with an array to store the UUID components.
  
These changes aim to enhance the software's performance and reliability, making it more efficient and user-friendly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->