### PR TITLE
Setup manual WASI & add memory ceiling

### DIFF
--- a/crates/wasm_runtime/src/lib.rs
+++ b/crates/wasm_runtime/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod limiting_tunables;
 pub mod wasm_runtime;
 
 #[cfg(test)]

--- a/crates/wasm_runtime/src/limiting_tunables.rs
+++ b/crates/wasm_runtime/src/limiting_tunables.rs
@@ -1,0 +1,124 @@
+use std::ptr::NonNull;
+use wasmer::{
+    vm::{self, MemoryStyle, TableStyle, VMMemoryDefinition, VMTableDefinition},
+    MemoryError, MemoryType, Pages, TableType, Tunables,
+};
+
+pub(crate) const DEFAULT_PAGE_LIMIT: Pages = Pages(24);
+
+/// A custom tunables that allows you to set a memory limit.
+///
+/// After adjusting the memory limits, it delegates all other logic
+/// to the base tunables.
+pub struct LimitingTunables<T: Tunables> {
+    /// The maximum a linear memory is allowed to be (in Wasm pages, 64 KiB each).
+    /// Since Wasmer ensures there is only none or one memory, this is practically
+    /// an upper limit for the guest memory.
+    limit: Pages,
+    /// The base implementation we delegate all the logic to
+    base: T,
+}
+
+impl<T: Tunables> LimitingTunables<T> {
+    pub fn new(base: T, limit: Pages) -> Self {
+        Self { limit, base }
+    }
+
+    /// Takes an input memory type as requested by the guest and sets
+    /// a maximum if missing. The resulting memory type is final if
+    /// valid. However, this can produce invalid types, such that
+    /// validate_memory must be called before creating the memory.
+    fn adjust_memory(&self, requested: &MemoryType) -> MemoryType {
+        let mut adjusted = requested.clone();
+        if requested.maximum.is_none() {
+            adjusted.maximum = Some(self.limit);
+        }
+        adjusted
+    }
+
+    /// Ensures the a given memory type does not exceed the memory limit.
+    /// Call this after adjusting the memory.
+    fn validate_memory(&self, ty: &MemoryType) -> Result<(), MemoryError> {
+        if ty.minimum > self.limit {
+            return Err(MemoryError::Generic(
+                "Minimum exceeds the allowed memory limit".to_string(),
+            ));
+        }
+
+        if let Some(max) = ty.maximum {
+            if max > self.limit {
+                return Err(MemoryError::Generic(
+                    "Maximum exceeds the allowed memory limit".to_string(),
+                ));
+            }
+        } else {
+            return Err(MemoryError::Generic("Maximum unset".to_string()));
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: Tunables> Tunables for LimitingTunables<T> {
+    /// Construct a `MemoryStyle` for the provided `MemoryType`
+    ///
+    /// Delegated to base.
+    fn memory_style(&self, memory: &MemoryType) -> MemoryStyle {
+        let adjusted = self.adjust_memory(memory);
+        self.base.memory_style(&adjusted)
+    }
+
+    /// Construct a `TableStyle` for the provided `TableType`
+    ///
+    /// Delegated to base.
+    fn table_style(&self, table: &TableType) -> TableStyle {
+        self.base.table_style(table)
+    }
+
+    /// Create a memory owned by the host given a [`MemoryType`] and a [`MemoryStyle`].
+    ///
+    /// The requested memory type is validated, adjusted to the limited and then passed to base.
+    fn create_host_memory(
+        &self,
+        ty: &MemoryType,
+        style: &MemoryStyle,
+    ) -> Result<vm::VMMemory, MemoryError> {
+        let adjusted = self.adjust_memory(ty);
+        self.validate_memory(&adjusted)?;
+        self.base.create_host_memory(&adjusted, style)
+    }
+
+    /// Create a memory owned by the VM given a [`MemoryType`] and a [`MemoryStyle`].
+    ///
+    /// Delegated to base.
+    unsafe fn create_vm_memory(
+        &self,
+        ty: &MemoryType,
+        style: &MemoryStyle,
+        vm_definition_location: NonNull<VMMemoryDefinition>,
+    ) -> Result<vm::VMMemory, MemoryError> {
+        let adjusted = self.adjust_memory(ty);
+        self.validate_memory(&adjusted)?;
+        self.base
+            .create_vm_memory(&adjusted, style, vm_definition_location)
+    }
+
+    /// Create a table owned by the host given a [`TableType`] and a [`TableStyle`].
+    ///
+    /// Delegated to base.
+    fn create_host_table(&self, ty: &TableType, style: &TableStyle) -> Result<vm::VMTable, String> {
+        self.base.create_host_table(ty, style)
+    }
+
+    /// Create a table owned by the VM given a [`TableType`] and a [`TableStyle`].
+    ///
+    /// Delegated to base.
+    unsafe fn create_vm_table(
+        &self,
+        ty: &TableType,
+        style: &TableStyle,
+        vm_definition_location: NonNull<VMTableDefinition>,
+    ) -> Result<vm::VMTable, String> {
+        self.base.create_vm_table(ty, style, vm_definition_location)
+    }
+}

--- a/crates/wasm_runtime/src/runtime_tests.rs
+++ b/crates/wasm_runtime/src/runtime_tests.rs
@@ -27,6 +27,10 @@ const TEST_LAST_BLOCK_TIME: i64 = 1689897402;
 const TEST_RETURN_FAIL: &str = "RETURN_FAIL";
 const VRRB_CONTRACT_NAME: &str = "vrrb-contract"; //argv[0] for smart contracts
 
+fn create_test_wasm_runtime(target: &Target, wasm_bytes: &[u8]) -> anyhow::Result<WasmRuntime> {
+    WasmRuntime::new::<Cranelift>(target, wasm_bytes)
+}
+
 /// This test checks that the stuff we send via stdin is available as part of
 /// the struct on stdout, per the wasm_test.wasm functionality. It shows we're
 /// able to properly set up the stdin and stdout pipes.
@@ -43,7 +47,7 @@ fn test_multiline_input() {
         last_block_time: TEST_LAST_BLOCK_TIME,
     };
     let target = Target::default();
-    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
+    let mut runtime = create_test_wasm_runtime(&target, &wasm_bytes)
         .unwrap()
         .stdin(&serde_json::to_vec(&inputs).unwrap())
         .unwrap();
@@ -63,7 +67,7 @@ fn test_single_line_input() {
     let wasm_bytes = std::fs::read("test_data/wasm_test.wasm").unwrap();
     let json_data = std::fs::read("test_data/wasm_test_oneline.json").unwrap();
     let target = Target::default();
-    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
+    let mut runtime = create_test_wasm_runtime(&target, &wasm_bytes)
         .unwrap()
         .stdin(&json_data)
         .unwrap();
@@ -92,7 +96,7 @@ fn test_command_line_args() {
         "us".to_string(),
     ];
     let target = Target::default();
-    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
+    let mut runtime = create_test_wasm_runtime(&target, &wasm_bytes)
         .unwrap()
         .stdin(&json_data)
         .unwrap()
@@ -118,7 +122,7 @@ fn test_environment_vars() {
     wasm_env.insert("PRICKLE".to_string(), "prickle".to_string());
     wasm_env.insert("GOO".to_string(), "goo".to_string());
     let target = Target::default();
-    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
+    let mut runtime = create_test_wasm_runtime(&target, &wasm_bytes)
         .unwrap()
         .stdin(&json_data)
         .unwrap()
@@ -142,7 +146,7 @@ fn test_failed_execution() {
     let mut wasm_env: HashMap<String, String> = HashMap::new();
     wasm_env.insert(TEST_RETURN_FAIL.to_string(), "true".to_string());
     let target = Target::default();
-    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
+    let mut runtime = create_test_wasm_runtime(&target, &wasm_bytes)
         .unwrap()
         .stdin(&json_data)
         .unwrap()

--- a/crates/wasm_runtime/src/runtime_tests.rs
+++ b/crates/wasm_runtime/src/runtime_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde_derive::{Deserialize, Serialize};
+use wasmer::{Cranelift, Target};
 
 use crate::wasm_runtime::WasmRuntime;
 
@@ -41,7 +42,8 @@ fn test_multiline_input() {
         tx_id: TEST_TX_ID.to_string(),
         last_block_time: TEST_LAST_BLOCK_TIME,
     };
-    let mut runtime = WasmRuntime::new(&wasm_bytes)
+    let target = Target::default();
+    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
         .unwrap()
         .stdin(&serde_json::to_vec(&inputs).unwrap())
         .unwrap();
@@ -60,7 +62,8 @@ fn test_multiline_input() {
 fn test_single_line_input() {
     let wasm_bytes = std::fs::read("test_data/wasm_test.wasm").unwrap();
     let json_data = std::fs::read("test_data/wasm_test_oneline.json").unwrap();
-    let mut runtime = WasmRuntime::new(&wasm_bytes)
+    let target = Target::default();
+    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
         .unwrap()
         .stdin(&json_data)
         .unwrap();
@@ -88,7 +91,8 @@ fn test_command_line_args() {
         "to".to_string(),
         "us".to_string(),
     ];
-    let mut runtime = WasmRuntime::new(&wasm_bytes)
+    let target = Target::default();
+    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
         .unwrap()
         .stdin(&json_data)
         .unwrap()
@@ -113,7 +117,8 @@ fn test_environment_vars() {
     wasm_env.insert("POKEY".to_string(), "pokey".to_string());
     wasm_env.insert("PRICKLE".to_string(), "prickle".to_string());
     wasm_env.insert("GOO".to_string(), "goo".to_string());
-    let mut runtime = WasmRuntime::new(&wasm_bytes)
+    let target = Target::default();
+    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
         .unwrap()
         .stdin(&json_data)
         .unwrap()
@@ -136,7 +141,8 @@ fn test_failed_execution() {
     let json_data = std::fs::read("test_data/wasm_test_oneline.json").unwrap();
     let mut wasm_env: HashMap<String, String> = HashMap::new();
     wasm_env.insert(TEST_RETURN_FAIL.to_string(), "true".to_string());
-    let mut runtime = WasmRuntime::new(&wasm_bytes)
+    let target = Target::default();
+    let mut runtime = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)
         .unwrap()
         .stdin(&json_data)
         .unwrap()

--- a/crates/wasm_runtime/src/wasm_runtime.rs
+++ b/crates/wasm_runtime/src/wasm_runtime.rs
@@ -35,7 +35,7 @@ impl WasmRuntime {
     /// in.
     ///
     /// C represents the compiler to use, which at the time of writing is Cranelift.
-    pub fn new<C: Default + Into<Engine>>(target: &Target, wasm_bytes: &Vec<u8>) -> Result<Self> {
+    pub fn new<C: Default + Into<Engine>>(target: &Target, wasm_bytes: &[u8]) -> Result<Self> {
         // Setup Tunables
         let compiler = C::default();
         let base = BaseTunables::for_target(target);

--- a/crates/wasm_runtime/src/wasm_runtime.rs
+++ b/crates/wasm_runtime/src/wasm_runtime.rs
@@ -10,9 +10,10 @@ use std::{
     io::{Read, Write},
 };
 
+use super::limiting_tunables::{LimitingTunables, DEFAULT_PAGE_LIMIT};
 use anyhow::Result;
 use telemetry::debug;
-use wasmer::{Module, Store};
+use wasmer::{BaseTunables, Engine, Instance, Module, NativeEngineExt, Store, Target};
 use wasmer_wasix::{Pipe, WasiEnv};
 
 /// This is the first command line argument, traditionally reserved for the
@@ -32,10 +33,18 @@ pub struct WasmRuntime {
 impl WasmRuntime {
     /// Creates a new WasmRuntime environment to execute the WASM binary passed
     /// in.
-    pub fn new(wasm_bytes: &Vec<u8>) -> Result<Self> {
+    ///
+    /// C represents the compiler to use, which at the time of writing is Cranelift.
+    pub fn new<C: Default + Into<Engine>>(target: &Target, wasm_bytes: &Vec<u8>) -> Result<Self> {
+        // Setup Tunables
+        let compiler = C::default();
+        let base = BaseTunables::for_target(target);
+        let tunables = LimitingTunables::new(base, DEFAULT_PAGE_LIMIT);
+        let mut engine: Engine = compiler.into();
+        engine.set_tunables(tunables);
         // Create an in-memory store for everything required to compile and run a WASM
         // module
-        let store = Store::default();
+        let store = Store::new(engine);
 
         debug!("Compiling {} bytes of WASM", wasm_bytes.len());
 
@@ -89,15 +98,38 @@ impl WasmRuntime {
         let (err_wasm, mut stderr) = Pipe::channel();
         stdin.write_all(&self.stdin)?;
         stdin.flush()?;
-        WasiEnv::builder(MODULE_ARGV0)
+
+        self.init_wasi_fn_env((in_wasm, out_wasm, err_wasm))?;
+
+        stdout.read_to_string(&mut self.stdout)?;
+        stderr.read_to_string(&mut self.stderr)?;
+        Ok(())
+    }
+
+    fn init_wasi_fn_env(
+        &mut self,
+        (in_wasm, out_wasm, err_wasm): (Pipe, Pipe, Pipe),
+    ) -> Result<()> {
+        let store = &mut self.store;
+        let module = &self.module;
+        let mut wasi_fn_env = WasiEnv::builder(MODULE_ARGV0)
             .stdin(Box::new(in_wasm))
             .stdout(Box::new(out_wasm))
             .stderr(Box::new(err_wasm))
             .args(Box::new(self.args.iter()))
             .envs(Box::new(self.env.iter()))
-            .run_with_store(self.module.to_owned(), &mut self.store)?;
-        stdout.read_to_string(&mut self.stdout)?;
-        stderr.read_to_string(&mut self.stderr)?;
-        Ok(())
+            .finalize(store)?;
+
+        let import_obj = wasi_fn_env.import_object(store, module)?;
+        let instance = Instance::new(store, module, &import_obj)?;
+
+        let mem_view = instance.exports.get_memory("memory")?.view(store);
+        telemetry::info!("Memory: {:?}", mem_view.size());
+
+        wasi_fn_env.initialize(store, instance.clone())?;
+        let start = instance.exports.get_function("_start")?;
+        start.call(store, &[])?;
+
+        Ok(wasi_fn_env.cleanup(store, None))
     }
 }


### PR DESCRIPTION
What this does:
- Adds the option to choose a compiler
- Adds a constant for the maximum number of pages
- Updates the `execute` method to using the manual WASI setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for adjusting and validating memory limits.
	- Enhanced the WasmRuntime struct to support different compilers and targets.
- **Tests**
	- Updated tests to include the use of the `wasmer` crate and the `Cranelift` compiler.
- **Refactor**
	- Added a method to initialize the WASI environment and execute WASI functions.
	- Modified the `new` method to use the provided engine when creating the store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->