### PR TITLE
Add `wasm_runtime` dependencies to `wasm_cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7438,6 +7438,7 @@ dependencies = [
  "vrrb_rpc",
  "wasm_loader",
  "wasm_runtime",
+ "wasmer",
  "web3_pkg",
 ]
 
@@ -7930,6 +7931,9 @@ dependencies = [
  "telemetry",
  "wasm_loader",
  "wasm_runtime",
+ "wasmer",
+ "wasmer-wasix",
+ "wasmer-wasix-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ prometheus = { workspace = true }
 hyper = { workspace = true }
 rand = { workspace = true }
 lazy_static = { workspace = true }
+wasmer = { workspace = true }
 
 [workspace]
 members = [
@@ -86,7 +87,7 @@ members = [
     "crates/storage_agent",
     "crates/service_config",
     "crates/web3_pkg",
-    "crates/platform"
+    "crates/platform",
 ]
 
 [workspace.dependencies]
@@ -181,7 +182,7 @@ jsonrpsee = { version = "0.16.2", features = [
 bytes = "1.3.0"
 reqwest = { version = "0.11.13", features = ["rustls-tls"] }
 sha2 = "0.10.6"
-sha3 = "0.10.8" 
+sha3 = "0.10.8"
 chrono = "0.4.23"
 lru_time_cache = "0.11.11"
 strum_macros = "0.21.0"

--- a/crates/wasm_cli/Cargo.toml
+++ b/crates/wasm_cli/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+wasmer = { workspace = true }
+wasmer-wasix = { workspace = true }
+wasmer-wasix-types = { workspace = true }
 wasm_loader = { workspace = true }
 wasm_runtime = { workspace = true }
 telemetry = { workspace = true }

--- a/crates/wasm_cli/src/commands/execute/mod.rs
+++ b/crates/wasm_cli/src/commands/execute/mod.rs
@@ -59,10 +59,7 @@ pub fn run(opts: &ExecuteOpts) -> Result<()> {
 
     let target = Target::default();
     // Execute the WASM module.
-    let mut wasm = WasmRuntime::new::<Cranelift>(
-        &target,
-        &wasm_bytes
-    )?
+    let mut wasm = WasmRuntime::new::<Cranelift>(&target, &wasm_bytes)?
         .stdin(&json_data)?
         .env(&env_vars)?
         .args(&opts.args)?;

--- a/crates/wasm_cli/src/commands/execute/mod.rs
+++ b/crates/wasm_cli/src/commands/execute/mod.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use telemetry::info;
 use wasm_runtime::wasm_runtime::WasmRuntime;
+use wasmer::{Cranelift, Target};
 
 #[derive(Parser, Debug)]
 pub struct ExecuteOpts {
@@ -56,8 +57,12 @@ pub fn run(opts: &ExecuteOpts) -> Result<()> {
         }
     }
 
+    let target = Target::default();
     // Execute the WASM module.
-    let mut wasm = WasmRuntime::new(&wasm_bytes)?
+    let mut wasm = WasmRuntime::new::<Cranelift>(
+        &target,
+        &wasm_bytes
+    )?
         .stdin(&json_data)?
         .env(&env_vars)?
         .args(&opts.args)?;


### PR DESCRIPTION
Adds dependencies and function arguments that were not updated for the `wasm_cli` crate in #661 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the use of the `wasmer` crate with the `Cranelift` compiler for improved WebAssembly module execution.
- **Refactor**
	- Modified the `run` function to initialize a new `WasmRuntime` with the specified target and wasm bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->