### PR TITLE
Update `apple_sdk` frameworks for libclang build inputs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -39,7 +39,7 @@ pkgs.mkShell {
     rocksdb
     openssl.dev
     libiconv
-  ] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
+  ] ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security darwin.apple_sdk.frameworks.SystemConfiguration];
 
   shellHook = ''
     export LIBCLANG_PATH="${pkgs.libclang.lib}/lib";


### PR DESCRIPTION
The latest MacOS updates required this framework in order to link ld.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced compatibility with Darwin systems by adding SystemConfiguration to the list of optional frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->