### PR TITLE
Feat prometheus base exporter 641

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ hyper = { workspace = true }
 rand = { workspace = true }
 lazy_static = { workspace = true }
 wasmer = { workspace = true }
+metric_exporter = { workspace = true }
 
 [workspace]
 members = [
@@ -88,6 +89,7 @@ members = [
     "crates/service_config",
     "crates/web3_pkg",
     "crates/platform",
+    "crates/metric_exporter"
 ]
 
 [workspace.dependencies]
@@ -126,6 +128,7 @@ wasm_runtime = { path = "crates/wasm_runtime" }
 service_config = { path = "crates/service_config" }
 web3_pkg = { path = "crates/web3_pkg" }
 platform = { path = "crates/platform" }
+metric_exporter = { path = "crates/metric_exporter"}
 
 # NOTE: Github crates
 patriecia = { git = "https://github.com/versatus/patriecia" }

--- a/crates/metric_exporter/Cargo.toml
+++ b/crates/metric_exporter/Cargo.toml
@@ -6,12 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hyper = { version = "0.14.27", features = ["full"] }
+hyper = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true}
-log = "0.4.20"
-async-trait = "0.1.74"
-rand = "0.8.5"
+log = { workspace = true}
+rand = { workspace = true}
 platform = { workspace = true}
 prometheus = { workspace = true}
 

--- a/crates/metric_exporter/Cargo.toml
+++ b/crates/metric_exporter/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "metric_exporter"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hyper = { version = "0.14.27", features = ["full"] }
+tokio = { workspace = true }
+thiserror = { workspace = true}
+log = "0.4.20"
+async-trait = "0.1.74"
+rand = "0.8.5"
+platform = { workspace = true}
+prometheus = { workspace = true}
+
+
+[[example]]
+name = "metrics_example"
+path = "src/examples/metrics_example.rs"

--- a/crates/metric_exporter/src/examples/metrics_example.rs
+++ b/crates/metric_exporter/src/examples/metrics_example.rs
@@ -1,0 +1,110 @@
+use metric_exporter::metric_factory::PrometheusFactory;
+use prometheus::labels;
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::thread;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    // Configuration
+    let port = 8080u16;
+    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
+    let labels = labels! {
+                "service".to_string() => "compute".to_string(),
+                "source".to_string() => "versatus".to_string(),
+    };
+    // Prometheus factory for metrics
+    let factory = Arc::new(PrometheusFactory::new(port, false, HashMap::new()));
+
+    // Metrics: Block height, Transactions per minute, CPU load, Active peers, Block finality time
+    let block_height = factory
+        .build_int_counter("block_height", "Current Block Height", labels.clone())
+        .unwrap();
+    let txn_histogram = factory
+        .build_histogram("no_of_txns", "No of txns per min", labels.clone())
+        .unwrap();
+    let cpu_load = factory
+        .build_gauge("current_cpu_load", "CPU Load", labels.clone())
+        .unwrap();
+    let active_peers = factory
+        .build_int_gauge("active_peers", "Active Peers", labels.clone())
+        .unwrap();
+    let block_finality = factory
+        .build_histogram("block_finality_time", "Block Finality Time", labels)
+        .unwrap();
+
+    // Simulating blockchain metrics
+    let server = factory.serve();
+
+    // Simulate block creation - Increment block height counter every 5 seconds
+    thread::spawn({
+        let block_height_clone = block_height.clone();
+        move || {
+            for _ in 0.. {
+                sleep(Duration::from_secs(5));
+                block_height_clone.inc();
+            }
+        }
+    });
+
+    // Simulate transactions - Observe transaction histogram every 10 seconds
+    thread::spawn({
+        let txn_histogram_clone = txn_histogram.clone();
+        move || {
+            for _ in 0.. {
+                txn_histogram_clone.observe(200000.0);
+                sleep(Duration::from_secs(10));
+            }
+        }
+    });
+
+    // Simulate CPU load changes - Set CPU load gauge randomly every 3 seconds
+    thread::spawn({
+        let cpu_load_clone = cpu_load.clone();
+        move || {
+            use rand::prelude::*;
+            let mut rng = rand::thread_rng();
+            for _ in 0.. {
+                let load: f64 = rng.gen_range(0.0..100.0);
+                cpu_load_clone.set(load);
+                sleep(Duration::from_secs(3));
+            }
+        }
+    });
+
+    // Simulate active peers - Randomly change active peers count every 15 seconds
+    thread::spawn({
+        let active_peers_clone = active_peers.clone();
+        move || {
+            use rand::prelude::*;
+            let mut rng = rand::thread_rng();
+            for _ in 0.. {
+                let peer_count: i64 = rng.gen_range(10..50); // Simulating between 10 to 50 peers as integers
+                active_peers_clone.set(peer_count);
+                sleep(Duration::from_secs(15));
+            }
+        }
+    });
+
+    // Simulate block finality time - Observe finality histogram every 30 seconds
+    thread::spawn({
+        let block_finality_clone = block_finality.clone();
+        move || {
+            for _ in 0.. {
+                let finality_time: f64 = 4.5; // Simulating a constant block finality time for demo purposes
+                block_finality_clone.observe(finality_time);
+                sleep(Duration::from_secs(30));
+            }
+        }
+    });
+
+    println!("Exporter listening on http://{}", addr);
+
+    // Await the server
+    if let Err(e) = server.await {
+        eprintln!("server error: {}", e);
+    }
+}

--- a/crates/metric_exporter/src/lib.rs
+++ b/crates/metric_exporter/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod metric_factory;
+pub mod render;

--- a/crates/metric_exporter/src/metric_factory.rs
+++ b/crates/metric_exporter/src/metric_factory.rs
@@ -1,0 +1,256 @@
+use crate::render::RenderToPrometheus;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server};
+use prometheus::proto::MetricFamily;
+use prometheus::{
+    core::Collector, Counter, Encoder, Gauge, Histogram, HistogramOpts, IntCounter, IntGauge, Opts,
+    Registry, TextEncoder,
+};
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use thiserror::Error;
+use platform::platform_stats::CgroupStats;
+
+#[derive(Debug, Error)]
+pub enum PrometheusFactoryError {
+    #[error("Prometheus registration error: {0}")]
+    RegistrationError(#[from] prometheus::Error),
+    #[error("Prometheus deregistration error")]
+    DeRegistrationError,
+    #[error("UTF-8 conversion error: {0}")]
+    Utf8ConversionError(#[from] std::string::FromUtf8Error),
+    #[error("Error occurred while creating hyper server : {0}")]
+    ServerError(#[from] hyper::Error),
+}
+
+trait MetricRegistrar {
+    fn register(&self, metric: Box<dyn Collector>) -> Result<(), PrometheusFactoryError>;
+    fn unregister(&self, metric: Box<dyn Collector>) -> Result<(), PrometheusFactoryError>;
+    fn gather_metrics(&self) -> Vec<MetricFamily>;
+    fn reset_registry(&mut self);
+}
+
+#[derive(Debug, Clone)]
+pub struct PrometheusFactory {
+    pub registry: Registry,
+    port: u16,
+    pub base_metrics: HashMap<String, Counter>,
+}
+
+impl PrometheusFactory {
+    pub fn new(
+        port: u16,
+        include_base_metrics: bool,
+        base_labels: HashMap<String, String>,
+    ) -> Self {
+        let mut factory = Self {
+            registry: Registry::new(),
+            port,
+            base_metrics: HashMap::new(),
+        };
+        if include_base_metrics {
+            Self::append_base_metrics(base_labels, &mut factory);
+        }
+        factory
+    }
+
+    fn append_base_metrics(base_labels: HashMap<String, String>, factory: &mut PrometheusFactory) {
+        let stats = CgroupStats::new().unwrap();
+        factory.set_or_update_base_counter_metric("cpu_total_usec", "CPU time used in usec total", base_labels.clone(), stats.cpu.cpu_total_usec as f64);
+        factory.set_or_update_base_counter_metric("cpu_user_usec", "CPU time used for userspace in usec", base_labels.clone(), stats.cpu.cpu_user_usec as f64);
+        factory.set_or_update_base_counter_metric("cpu_system_usec", "CPU time used for kernel in usec", base_labels.clone(), stats.cpu.cpu_system_usec as f64);
+        factory.set_or_update_base_counter_metric("mem_anon_bytes", "Anonymous memory used in bytes", base_labels.clone(), stats.mem.mem_anon_bytes as f64);
+        factory.set_or_update_base_counter_metric("mem_file_bytes", "File-backed memory used in bytes", base_labels.clone(), stats.mem.mem_file_bytes as f64);
+        factory.set_or_update_base_counter_metric("mem_sock_bytes", "Socket memory used in bytes", base_labels.clone(), stats.mem.mem_sock_bytes as f64);
+    }
+    pub fn set_or_update_base_counter_metric(
+        &mut self,
+        name: &str,
+        help: &str,
+        labels: HashMap<String, String>,
+        value: f64,
+    ) {
+        let metric = match self.base_metrics.get_mut(name) {
+            Some(existing_metric) => existing_metric,
+            None => {
+                let counter = self.build_counter(name, help, labels).unwrap();
+                self.base_metrics.insert(name.to_string(), counter);
+                self.base_metrics.get_mut(name).unwrap()
+            }
+        };
+        metric.reset();
+        metric.inc_by(value);
+    }
+
+}
+
+
+    impl MetricRegistrar for PrometheusFactory {
+    fn register(&self, metric: Box<dyn Collector>) -> Result<(), PrometheusFactoryError> {
+        self.registry
+            .register(metric)
+            .map_err(PrometheusFactoryError::RegistrationError)
+    }
+
+    fn unregister(&self, metric: Box<dyn Collector>) -> Result<(), PrometheusFactoryError> {
+        self.registry
+            .unregister(metric)
+            .map_err(PrometheusFactoryError::RegistrationError)
+    }
+
+    fn gather_metrics(&self) -> Vec<MetricFamily> {
+        self.registry.gather()
+    }
+
+    fn reset_registry(&mut self) {
+        self.registry = Registry::new();
+    }
+}
+
+impl PrometheusFactory {
+    pub fn build_counter(
+        &self,
+        name: &str,
+        help: &str,
+        labels: HashMap<String, String>,
+    ) -> Result<Counter, PrometheusFactoryError> {
+        let opts = Opts::new(name, help).const_labels(labels);
+        Counter::with_opts(opts.clone())
+            .map_err(PrometheusFactoryError::RegistrationError)
+            .and_then(|counter| {
+                self.register(Box::new(counter.clone()))?;
+                Ok(counter)
+            })
+    }
+
+    pub fn build_histogram(
+        &self,
+        name: &str,
+        help: &str,
+        labels: HashMap<String, String>,
+    ) -> Result<Histogram, PrometheusFactoryError> {
+        let histogram_opts = HistogramOpts::new(name, help).const_labels(labels);
+        Histogram::with_opts(histogram_opts)
+            .map_err(PrometheusFactoryError::RegistrationError)
+            .and_then(|histogram| {
+                self.register(Box::new(histogram.clone()))?;
+                Ok(histogram)
+            })
+    }
+
+    pub fn build_gauge(
+        &self,
+        name: &str,
+        help: &str,
+        labels: HashMap<String, String>,
+    ) -> Result<Gauge, PrometheusFactoryError> {
+        let opts = Opts::new(name, help).const_labels(labels);
+        Gauge::with_opts(opts)
+            .map_err(PrometheusFactoryError::RegistrationError)
+            .and_then(|gauge| {
+                self.register(Box::new(gauge.clone()))?;
+                Ok(gauge)
+            })
+    }
+
+    pub fn build_int_counter(
+        &self,
+        name: &str,
+        help: &str,
+        labels: HashMap<String, String>,
+    ) -> Result<IntCounter, PrometheusFactoryError> {
+        let opts = Opts::new(name, help).const_labels(labels);
+        IntCounter::with_opts(opts.clone())
+            .map_err(PrometheusFactoryError::RegistrationError)
+            .and_then(|counter| {
+                self.register(Box::new(counter.clone()))?;
+                Ok(counter)
+            })
+    }
+
+    pub fn build_int_gauge(
+        &self,
+        name: &str,
+        help: &str,
+        labels: HashMap<String, String>,
+    ) -> Result<IntGauge, PrometheusFactoryError> {
+        let opts = Opts::new(name, help).const_labels(labels);
+        IntGauge::with_opts(opts.clone())
+            .map_err(PrometheusFactoryError::RegistrationError)
+            .and_then(|gauge| {
+                self.register(Box::new(gauge.clone()))?;
+                Ok(gauge)
+            })
+    }
+    async fn handle_request(
+        _req: Request<Body>,
+        factory: PrometheusFactory,
+    ) -> Result<Response<Body>, PrometheusFactoryError> {
+        let response_body = factory.render_metrics()?;
+        Ok(Response::new(Body::from(response_body)))
+    }
+    pub async fn serve(&self) -> Result<(), PrometheusFactoryError> {
+        {
+            let make_svc = make_service_fn(move |_conn| {
+                let factory = self.clone();
+                async move {
+                    Ok::<_, hyper::Error>(service_fn(move |req| {
+                        let factory = factory.clone();
+                        Self::handle_request(req, factory)
+                    }))
+                }
+            });
+
+            let socket_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, self.port));
+            let server = Server::try_bind(&socket_addr)
+                .map_err(PrometheusFactoryError::ServerError)?
+                .serve(make_svc);
+
+            log::info!("Exporter listening on http://{}", socket_addr);
+
+            if let Err(e) = server.await {
+                eprintln!("server error: {}", e);
+            }
+            Ok(())
+        }
+    }
+}
+
+impl RenderToPrometheus for PrometheusFactory {
+    fn render_metrics(&self) -> Result<String, PrometheusFactoryError> {
+        let encoder = TextEncoder::new();
+        let mut buffer = vec![];
+        encoder.encode(&self.gather_metrics(), &mut buffer)?;
+        String::from_utf8(buffer).map_err(PrometheusFactoryError::Utf8ConversionError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus::labels;
+    #[test]
+    fn test_reset_factory() {
+        let mut factory = PrometheusFactory::new(8080, false, HashMap::new());
+        let labels = labels! {
+                "service".to_string() => "compute".to_string(),
+                "source".to_string() => "versatus".to_string(),
+        };
+        let counter = factory
+            .build_counter("counter", " counter metric", labels.clone())
+            .unwrap();
+        let gauge = factory
+            .build_gauge("gauge", " gauge metric", labels.clone())
+            .unwrap();
+        let histogram = factory
+            .build_histogram("histogram", " histogram metric", labels)
+            .unwrap();
+        counter.inc();
+        gauge.set(12.0);
+        gauge.inc();
+        histogram.observe(7.0);
+        assert_eq!(factory.gather_metrics().len(), 3);
+        factory.reset_registry();
+        assert_eq!(factory.gather_metrics().len(), 0);
+    }
+}

--- a/crates/metric_exporter/src/render.rs
+++ b/crates/metric_exporter/src/render.rs
@@ -1,0 +1,5 @@
+use crate::metric_factory::PrometheusFactoryError;
+
+pub trait RenderToPrometheus: std::fmt::Debug {
+    fn render_metrics(&self) -> Result<String, PrometheusFactoryError>;
+}


### PR DESCRIPTION
## Description

### Summary
This pull request introduces the Prometheus Factory, a new component that enables the creation of various types of metrics like gauge, counter, and histogram. Additionally, it includes base-level metrics and integrates a server for rendering these metrics.

### Changes Made
- Added the Prometheus Factory module, allowing for dynamic creation of metrics (gauges, counters, histograms).
- Included base-level metrics to provide essential system-wide data.
- Integrated a server for rendering the metrics, providing a visual representation and access.


### Dependencies
This PR introduces dependencies on the Prometheus library for metric handling and a lightweight server framework for rendering and serving metrics.

### Related Issues
- [ ] This doesn't support base level metrics of other platforms like macOS, it supports only Linux

## Checklist
- [x] Implemented the Prometheus Factory for creating various metric types.
- [x] Added base-level metrics for system-wide data.
- [x] Integrated a server to render and provide access to metrics.
- [x] Wrote unit test and sample example file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new example program for blockchain-related metrics using Prometheus.
  - Added new modules for creating, registering, and serving Prometheus metrics.
  - Implemented a new trait for rendering metrics to Prometheus format.

- **Enhancements**
  - Improved error handling with a custom error type for Prometheus metric operations.

- **Documentation**
  - The release notes do not explicitly mention updates to documentation, but new features typically include corresponding documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->