### PR TITLE
Refactor panics from entries method on stores within storage crate.

### DIFF
--- a/crates/node/src/runtime/handler_helpers.rs
+++ b/crates/node/src/runtime/handler_helpers.rs
@@ -376,7 +376,12 @@ impl NodeRuntime {
 
     // TODO: Replace claims HashMap with claim_store_read_handle_factory
     pub fn handle_quorum_election_started(&mut self, header: BlockHeader) -> Result<()> {
-        let claims = self.state_driver.read_handle().claim_store_values();
+        let claims = self
+            .state_driver
+            .read_handle()
+            .claim_store_values()
+            .map_err(|err| NodeError::Other(format!("unable to read claims from store: {err}")))?;
+
         let quorums = self
             .consensus_driver
             .handle_quorum_election_started(header, claims)?;
@@ -405,6 +410,7 @@ impl NodeRuntime {
             };
             inaug_members.0.insert(quorum_id, quorum_data);
         });
+
         self.pending_quorum = Some(inaug_members);
 
         //        let local_id = self.config.id.clone();

--- a/crates/node/src/runtime/node_runtime.rs
+++ b/crates/node/src/runtime/node_runtime.rs
@@ -445,14 +445,14 @@ impl NodeRuntime {
         Ok(handle.state_store_values()?)
     }
 
-    pub fn transactions_snapshot(&self) -> HashMap<TransactionDigest, TransactionKind> {
+    pub fn transactions_snapshot(&self) -> Result<HashMap<TransactionDigest, TransactionKind>> {
         let handle = self.state_driver.read_handle();
-        handle.transaction_store_values()
+        Ok(handle.transaction_store_values()?)
     }
 
-    pub fn claims_snapshot(&self) -> HashMap<NodeId, Claim> {
+    pub fn claims_snapshot(&self) -> Result<HashMap<NodeId, Claim>> {
         let handle = self.state_driver.read_handle();
-        handle.claim_store_values()
+        Ok(handle.claim_store_values()?)
     }
 
     async fn _get_transaction_by_id(

--- a/crates/node/src/runtime/node_runtime_handler.rs
+++ b/crates/node/src/runtime/node_runtime_handler.rs
@@ -77,7 +77,9 @@ impl Handler<EventMessage> for NodeRuntime {
 
                         //add the addresses from config.bootstrap_config.additional_genesis_receivers to the genesis_receivers list
                         if let (Some(bootstrap_config)) = (&self.config.bootstrap_config) {
-                            if let (Some(additional_genesis_receivers)) = (&bootstrap_config.additional_genesis_receivers) {
+                            if let (Some(additional_genesis_receivers)) =
+                                (&bootstrap_config.additional_genesis_receivers)
+                            {
                                 for receiver in additional_genesis_receivers {
                                     genesis_receivers.push(GenesisReceiver::new(receiver.clone()));
                                 }
@@ -86,9 +88,7 @@ impl Handler<EventMessage> for NodeRuntime {
 
                         let event = EventMessage::new(
                             Some(RUNTIME_TOPIC_STR.into()),
-                            Event::GenesisMinerElected {
-                                genesis_receivers
-                            },
+                            Event::GenesisMinerElected { genesis_receivers },
                         );
                         self.events_tx
                             .send(event)
@@ -105,7 +105,11 @@ impl Handler<EventMessage> for NodeRuntime {
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
             },
             Event::MinerElectionStarted(header) => {
-                let claims = self.state_driver.read_handle().claim_store_values();
+                let claims = self
+                    .state_driver
+                    .read_handle()
+                    .claim_store_values()
+                    .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 let results = self
                     .consensus_driver
@@ -234,7 +238,11 @@ impl Handler<EventMessage> for NodeRuntime {
             },
             Event::BlockCreated(mut block) => {
                 let node_id = self.config_ref().id.clone();
-                telemetry::info!("node {} received block from network with block id {}", node_id, block.hash());
+                telemetry::info!(
+                    "node {} received block from network with block id {}",
+                    node_id,
+                    block.hash()
+                );
 
                 let next_event = self
                     .state_driver

--- a/crates/node/src/state_manager/manager.rs
+++ b/crates/node/src/state_manager/manager.rs
@@ -459,6 +459,7 @@ impl StateManager {
             .claim_store_factory()
             .handle()
             .entries()
+            .map_err(|err| NodeError::Other(err.to_string()))?
             .clone()
             .into_iter()
             .filter(|(_, claim)| claim_hashes.contains(&claim.hash))
@@ -472,6 +473,7 @@ impl StateManager {
             .claim_store_factory()
             .handle()
             .entries()
+            .map_err(|err| NodeError::Other(err.to_string()))?
             .clone()
             .into_iter()
             .filter(|(_, claim)| &claim.address == address)
@@ -582,11 +584,17 @@ impl StateReader for VrrbDbReadHandle {
         Ok(values)
     }
 
-    fn transaction_store_values(&self) -> HashMap<TransactionDigest, TransactionKind> {
-        self.transaction_store_values()
+    fn transaction_store_values(&self) -> Result<HashMap<TransactionDigest, TransactionKind>> {
+        let values = self
+            .transaction_store_values()
+            .map_err(|err| StorageError::Other(format!("failed to read transactions: {err}")))?;
+        Ok(values)
     }
 
-    fn claim_store_values(&self) -> HashMap<NodeId, Claim> {
-        self.claim_store_values()
+    fn claim_store_values(&self) -> Result<HashMap<NodeId, Claim>> {
+        let values = self
+            .claim_store_values()
+            .map_err(|err| StorageError::Other(format!("failed to read claims: {err}")))?;
+        Ok(values)
     }
 }

--- a/crates/node/src/state_reader.rs
+++ b/crates/node/src/state_reader.rs
@@ -3,11 +3,8 @@ use std::collections::HashMap;
 use block::{Block, ClaimHash};
 use primitives::{Address, NodeId, Round};
 use storage::vrrbdb::Claims;
-use vrrb_core::{
-    account::Account,
-    claim::Claim,
-};
 use vrrb_core::transactions::{TransactionDigest, TransactionKind};
+use vrrb_core::{account::Account, claim::Claim};
 
 use crate::Result;
 
@@ -20,7 +17,10 @@ pub trait StateReader: std::fmt::Debug {
     async fn mempool_snapshot(&self) -> Result<HashMap<TransactionDigest, TransactionKind>>;
 
     /// Get a transaction from state
-    async fn get_transaction(&self, transaction_digest: TransactionDigest) -> Result<TransactionKind>;
+    async fn get_transaction(
+        &self,
+        transaction_digest: TransactionDigest,
+    ) -> Result<TransactionKind>;
 
     /// List a group of transactions
     async fn list_transactions(
@@ -48,7 +48,7 @@ pub trait StateReader: std::fmt::Debug {
     fn state_store_values(&self) -> Result<HashMap<Address, Account>>;
 
     /// Returns a copy of all values stored within the state trie
-    fn transaction_store_values(&self) -> HashMap<TransactionDigest, TransactionKind>;
+    fn transaction_store_values(&self) -> Result<HashMap<TransactionDigest, TransactionKind>>;
 
-    fn claim_store_values(&self) -> HashMap<NodeId, Claim>;
+    fn claim_store_values(&self) -> Result<HashMap<NodeId, Claim>>;
 }

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -501,107 +501,6 @@ pub fn create_mock_transaction_args(n: usize) -> NewTransferArgs {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct MockStateStore {}
-
-impl MockStateStore {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct MockStateReader {}
-
-impl MockStateReader {
-    pub fn new() -> Self {
-        MockStateReader {}
-    }
-}
-
-#[async_trait]
-impl StateReader for MockStateReader {
-    /// Returns a full list of all accounts within state
-    async fn state_snapshot(&self) -> Result<HashMap<Address, Account>> {
-        todo!()
-    }
-
-    /// Returns a full list of transactions pending to be confirmed
-    async fn mempool_snapshot(&self) -> Result<HashMap<TransactionDigest, TransactionKind>> {
-        todo!()
-    }
-
-    /// Get a transaction from state
-    async fn get_transaction(
-        &self,
-        transaction_digest: TransactionDigest,
-    ) -> Result<TransactionKind> {
-        todo!()
-    }
-
-    /// List a group of transactions
-    async fn list_transactions(
-        &self,
-        digests: Vec<TransactionDigest>,
-    ) -> Result<HashMap<TransactionDigest, TransactionKind>> {
-        todo!()
-    }
-
-    async fn get_account(&self, address: Address) -> Result<Account> {
-        todo!()
-    }
-
-    async fn get_round(&self) -> Result<Round> {
-        todo!()
-    }
-
-    async fn get_blocks(&self) -> Result<Vec<Block>> {
-        todo!()
-    }
-
-    async fn get_transaction_count(&self) -> Result<usize> {
-        todo!()
-    }
-
-    async fn get_claims_by_account_id(&self) -> Result<Vec<Claim>> {
-        todo!()
-    }
-
-    async fn get_claim_hashes(&self) -> Result<Vec<ClaimHash>> {
-        todo!()
-    }
-
-    async fn get_claims(&self, claim_hashes: Vec<ClaimHash>) -> Result<Claims> {
-        todo!()
-    }
-
-    async fn get_last_block(&self) -> Result<Block> {
-        todo!()
-    }
-
-    fn state_store_values(&self) -> Result<HashMap<Address, Account>> {
-        todo!()
-    }
-
-    /// Returns a copy of all values stored within the state trie
-    fn transaction_store_values(&self) -> HashMap<TransactionDigest, TransactionKind> {
-        todo!()
-    }
-
-    fn claim_store_values(&self) -> HashMap<NodeId, Claim> {
-        todo!()
-    }
-}
-
-#[async_trait]
-impl DataStore<MockStateReader> for MockStateStore {
-    type Error = NodeError;
-
-    fn state_reader(&self) -> MockStateReader {
-        todo!()
-    }
-}
-
 /// Creates `n` Node instances that make up a network.
 pub async fn create_test_network(n: u16) -> Vec<Node> {
     create_test_network_from_config(n, None).await
@@ -708,7 +607,7 @@ pub async fn create_test_network_from_config(n: u16, base_config: Option<NodeCon
         let quorum_config = quorum_members.get(&node_id).unwrap().to_owned();
 
         config.id = format!("node-{}", i);
-        config.keypair = keypairs.get(i-1).unwrap().clone();
+        config.keypair = keypairs.get(i - 1).unwrap().clone();
         config.bootstrap_config = Some(bootstrap_node_config.clone());
         config.node_type = NodeType::Validator;
         config.kademlia_liveness_address = quorum_config.kademlia_liveness_address;
@@ -728,7 +627,7 @@ pub async fn create_test_network_from_config(n: u16, base_config: Option<NodeCon
         let quorum_config = quorum_members.get(&node_id).unwrap().to_owned();
 
         miner_config.id = format!("node-{}", i);
-        miner_config.keypair = keypairs.get(i-1).unwrap().clone();
+        miner_config.keypair = keypairs.get(i - 1).unwrap().clone();
         miner_config.bootstrap_config = Some(bootstrap_node_config.clone());
         miner_config.node_type = NodeType::Miner;
         miner_config.kademlia_liveness_address = quorum_config.kademlia_liveness_address;

--- a/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
+++ b/crates/storage/vrrbdb/src/claim_store/claim_store_rh.rs
@@ -42,11 +42,14 @@ impl ClaimStoreReadHandle {
         claims
     }
 
-    pub fn entries(&self) -> HashMap<NodeId, Claim> {
+    pub fn entries(&self) -> Result<HashMap<NodeId, Claim>> {
         // TODO: revisit and refactor into inner wrapper
-        self.inner
+        Ok(self
+            .inner
             .iter(self.inner.version())
-            .unwrap()
+            .map_err(|err| {
+                StorageError::Other(format!("unable to create iterator from trie: {}", err))
+            })?
             .filter_map(|item| {
                 if let Ok((_, claim)) = item {
                     if let Ok(claim) = bincode::deserialize::<Claim>(&claim) {
@@ -56,7 +59,7 @@ impl ClaimStoreReadHandle {
                 }
                 None
             })
-            .collect()
+            .collect())
     }
 
     /// Returns a number of initialized claims in the database

--- a/crates/storage/vrrbdb/src/state_store/state_store_rh.rs
+++ b/crates/storage/vrrbdb/src/state_store/state_store_rh.rs
@@ -32,10 +32,7 @@ impl StateStoreReadHandle {
     ///
     /// Returns HashMap indexed by PublicKeys and containing either
     /// Some(account) or None if account was not found.
-    pub fn batch_get(
-        &self,
-        keys: Vec<Address>,
-    ) -> HashMap<Address, Option<Account>> {
+    pub fn batch_get(&self, keys: Vec<Address>) -> HashMap<Address, Option<Account>> {
         let mut accounts = HashMap::new();
 
         keys.iter().for_each(|key| {

--- a/crates/storage/vrrbdb/src/transaction_store/transaction_store_rh.rs
+++ b/crates/storage/vrrbdb/src/transaction_store/transaction_store_rh.rs
@@ -39,11 +39,14 @@ impl TransactionStoreReadHandle {
         transactions
     }
 
-    pub fn entries(&self) -> HashMap<TransactionDigest, TransactionKind> {
+    pub fn entries(&self) -> Result<HashMap<TransactionDigest, TransactionKind>> {
         // TODO: revisit and refactor into inner wrapper
-        self.inner
+        Ok(self
+            .inner
             .iter(self.inner.version())
-            .unwrap()
+            .map_err(|err| {
+                StorageError::Other(format!("unable to create iterator from trie: {}", err))
+            })?
             .filter_map(|item| {
                 if let Ok((_, txn)) = item {
                     let txn = bincode::deserialize::<TransactionKind>(&txn).unwrap_or_default();
@@ -52,7 +55,7 @@ impl TransactionStoreReadHandle {
                 }
                 None
             })
-            .collect()
+            .collect())
     }
 
     /// Returns a number of transactions in the ledger

--- a/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb_read_handle.rs
@@ -38,13 +38,13 @@ impl VrrbDbReadHandle {
 
     // TODO: rewrite these to get start at the first key available and the latest version
     /// Returns a copy of all values stored within the state trie
-    pub fn transaction_store_values(&self) -> HashMap<TransactionDigest, TransactionKind> {
+    pub fn transaction_store_values(&self) -> Result<HashMap<TransactionDigest, TransactionKind>> {
         self.transaction_store_handle_factory.handle().entries()
     }
 
     // TODO: rewrite these to get start at the first key available and the latest version
     /// Returns a copy of all values stored within the state trie
-    pub fn claim_store_values(&self) -> HashMap<NodeId, Claim> {
+    pub fn claim_store_values(&self) -> Result<HashMap<NodeId, Claim>> {
         self.claim_store_handle_factory.handle().entries()
     }
 


### PR DESCRIPTION
Previously `entries` methods on tries managed by the storage crate called `unwrap` when unable to create an iterator from empty tries. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved error handling across various components to ensure robustness and consistency.
  - Enhanced code readability and maintainability in several modules.

- **Bug Fixes**
  - Addressed potential issues by adding error propagation in functions that interact with the state and transaction stores.

- **Style**
  - Code formatting has been standardized to improve clarity and coherence throughout the codebase.

- **Tests**
  - Updated test utilities to align with changes in keypair handling and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->