### PR TITLE
Remove hardcoded level from custom telemetry subscriber

### DIFF
--- a/crates/telemetry/src/custom_subscriber.rs
+++ b/crates/telemetry/src/custom_subscriber.rs
@@ -34,8 +34,7 @@ impl TelemetrySubscriber {
                 .with_line_number(is_local_env)
                 .with_target(is_local_env)
                 .compact()
-                // .pretty()
-                .with_max_level(tracing::Level::ERROR)
+                .pretty()
                 .finish();
 
             sub.try_init()?;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved telemetry output formatting for better readability.
  - Removed restriction on log level to capture more detailed telemetry data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->