### PR TITLE
Faucet for token distribution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ name = "versa-storage"
 path = "crates/storage_agent/src/main.rs"
 
 [dependencies]
+faucet = { workspace = true }
 tokio = { workspace = true }
 telemetry = { workspace = true }
 cli = { workspace = true }
@@ -59,6 +60,7 @@ metric_exporter = { workspace = true }
 members = [
     "crates/primitives",
     "crates/events",
+    "crates/faucet",
     "crates/consensus",
     "crates/consensus/quorum",
     # "crates/consensus/dkg_engine",
@@ -100,6 +102,7 @@ primitives = { path = "crates/primitives" }
 vrrb_core = { path = "crates/vrrb_core" }
 vrrb_config = { path = "crates/vrrb_config" }
 vrrb_rpc = { path = "crates/vrrb_rpc" }
+faucet = { path = "crates/faucet" }
 block = { path = "crates/block" }
 miner = { path = "crates/miner" }
 wallet = { path = "crates/wallet" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = { workspace = true }
+faucet = { workspace = true }
 tokio = { workspace = true }
 node = { workspace = true }
 vrrb_config = { workspace = true }

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 
 use crate::commands::{config::ConfigOpts, keygen::KeygenCmd, node::NodeOpts, wallet::WalletOpts};
 use crate::commands::dev::DevOpts;
+use crate::commands::faucet::FaucetOpts;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None, arg_required_else_help(true))]
@@ -40,4 +41,7 @@ pub enum Commands {
 
     /// Manage keypair creation
     Keygen(KeygenCmd),
+
+    /// Start a faucet server to transfer tokens to accounts
+    Faucet(FaucetOpts),
 }

--- a/crates/cli/src/commands/faucet/mod.rs
+++ b/crates/cli/src/commands/faucet/mod.rs
@@ -10,6 +10,9 @@ use wallet::v2::{AddressAlias, Wallet, WalletConfig};
 
 use crate::result::{CliError, Result};
 
+const DEFAULT_JSONRPC_ADDRESS: &str = "127.0.0.1:9293";
+const DEFAULT_FAUCET_PORT: u16 = 9294;
+
 #[derive(Debug, Subcommand)]
 pub enum FaucetCmd {
     /// Run a faucet with the provided configuration
@@ -21,7 +24,7 @@ pub struct FaucetOpts {
     #[clap(subcommand)]
     pub subcommand: FaucetCmd,
 
-    #[clap(long, default_value = "127.0.0.1:9293")]
+    #[clap(long, default_value = DEFAULT_JSONRPC_ADDRESS)]
     pub rpc_server_address: SocketAddr,
 
     /// Secret key to use when signing transactions
@@ -29,7 +32,7 @@ pub struct FaucetOpts {
     pub secret_key: String,
 
     /// Secret key to use when signing transactions
-    #[clap(long, default_value = "9294")]
+    #[clap(long, default_value = DEFAULT_FAUCET_PORT)]
     pub host_port: String,
 }
 

--- a/crates/cli/src/commands/faucet/mod.rs
+++ b/crates/cli/src/commands/faucet/mod.rs
@@ -1,0 +1,65 @@
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr};
+
+use clap::{Parser, Subcommand};
+use primitives::Address;
+use serde_json;
+use faucet::faucet::{FaucetConfig, Faucet};
+use vrrb_core::{account::Account, helpers::read_or_generate_keypair_file};
+use vrrb_core::transactions::Token;
+use wallet::v2::{AddressAlias, Wallet, WalletConfig};
+
+use crate::result::{CliError, Result};
+
+#[derive(Debug, Subcommand)]
+pub enum FaucetCmd {
+    /// Run a faucet with the provided configuration
+    Run,
+}
+
+#[derive(Parser, Debug)]
+pub struct FaucetOpts {
+    #[clap(subcommand)]
+    pub subcommand: FaucetCmd,
+
+    #[clap(long, default_value = "127.0.0.1:9293")]
+    pub rpc_server_address: SocketAddr,
+
+    /// Secret key to use when signing transactions
+    #[clap(long)]
+    pub secret_key: String,
+
+    /// Secret key to use when signing transactions
+    #[clap(long, default_value = "9294")]
+    pub host_port: String,
+}
+
+pub async fn exec(args: FaucetOpts) -> Result<()> {
+
+    let sub_cmd = args.subcommand;
+
+    match sub_cmd {
+        FaucetCmd::Run => {
+            let config = FaucetConfig {
+                rpc_server_address: args.rpc_server_address,
+                server_port: args.host_port.parse::<u16>().unwrap(),
+                secret_key: args.secret_key,
+                transfer_amount: 10,
+            };
+
+            let faucet = Faucet::new(config)
+                .await;
+
+            if let Err(err) = faucet {
+                return Err(CliError::Other(format!("Failed to create faucet: {}", err)));
+            }
+            if let Ok(faucet) = faucet {
+                faucet.start().await.map_err(|err| {
+                    CliError::Other(format!("Failed to start faucet: {}", err))
+                })
+            } else {
+                Err(CliError::Other("Failed to create faucet".to_string()))
+            }
+        },
+        _ => Err(CliError::InvalidCommand(format!("{sub_cmd:?}"))),
+    }
+}

--- a/crates/cli/src/commands/faucet/mod.rs
+++ b/crates/cli/src/commands/faucet/mod.rs
@@ -11,7 +11,7 @@ use wallet::v2::{AddressAlias, Wallet, WalletConfig};
 use crate::result::{CliError, Result};
 
 const DEFAULT_JSONRPC_ADDRESS: &str = "127.0.0.1:9293";
-const DEFAULT_FAUCET_PORT: u16 = 9294;
+const DEFAULT_FAUCET_PORT: &str = "9294";
 
 #[derive(Debug, Subcommand)]
 pub enum FaucetCmd {

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod dev;
 pub mod node;
 pub mod utils;
 pub mod wallet;
+pub mod faucet;
 
 use crate::{
     cli::{Args, Commands},
@@ -20,6 +21,7 @@ pub async fn exec(args: Args) -> Result<()> {
         Some(Commands::Node(node_args)) => node::exec(*node_args).await,
         Some(Commands::Wallet(wallet_args)) => wallet::exec(wallet_args).await,
         Some(Commands::Keygen(keygen_args)) => keygen::exec(keygen_args),
+        Some(Commands::Faucet(faucet_args)) => faucet::exec(faucet_args).await,
         None => Err(CliError::NoSubcommand),
         _ => Err(CliError::InvalidCommand(format!("{cmd:?}"))),
     }

--- a/crates/faucet/Cargo.toml
+++ b/crates/faucet/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "faucet"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axum = { version = "0.5.17", features = ["macros"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1", features = ["full"] }
+chrono = "0.4.31"
+
+telemetry = { workspace = true }
+wallet = { workspace = true }
+vrrb_core = { workspace = true }
+primitives = { workspace = true }
+log = { version = "0.4.20", features = [] }
+

--- a/crates/faucet/src/faucet.rs
+++ b/crates/faucet/src/faucet.rs
@@ -8,6 +8,7 @@ use axum::routing::post;
 use tokio::spawn;
 use tokio::sync::Mutex;
 use primitives::Address;
+use telemetry::error;
 use vrrb_core::transactions::{RpcTransactionDigest, Token};
 use wallet::v2::{Wallet, WalletConfig, WalletError};
 
@@ -48,6 +49,7 @@ async fn drip(
         )
         .await
         .map_err(|err| {
+            error!("Unable to send transaction: {}", err);
             eprintln!("Unable to send transaction: {}", err);
             StatusCode::INTERNAL_SERVER_ERROR
         })?;

--- a/crates/faucet/src/faucet.rs
+++ b/crates/faucet/src/faucet.rs
@@ -1,0 +1,89 @@
+use axum::{Extension, http::StatusCode, Json, Router};
+
+use serde::Deserialize;
+use serde_json::json;
+use std::{convert::Infallible, net::SocketAddr};
+use std::sync::Arc;
+use axum::routing::post;
+use tokio::spawn;
+use tokio::sync::Mutex;
+use primitives::Address;
+use vrrb_core::transactions::{RpcTransactionDigest, Token};
+use wallet::v2::{Wallet, WalletConfig, WalletError};
+
+#[derive(Deserialize)]
+struct FaucetRequest {
+    address: String,
+}
+
+pub struct FaucetConfig {
+    pub rpc_server_address: SocketAddr,
+    pub server_port: u16,
+    pub secret_key: String,
+    pub transfer_amount: u64,
+}
+
+pub struct Faucet {
+    config: FaucetConfig,
+    wallet: Arc<Mutex<Wallet>>,
+}
+async fn drip(
+    Extension(wallet): Extension<Arc<Mutex<Wallet>>>,
+    Json(req): Json<FaucetRequest>,
+) -> Result<Json<RpcTransactionDigest>, StatusCode> {
+    let recipient: Address = req.address.parse().unwrap();
+
+    let timestamp = chrono::Utc::now().timestamp();
+
+    // Locking wallet for mutation.
+    let mut wallet = wallet.lock().await;
+
+    let digest = wallet
+        .send_transaction(
+            // 0,
+            recipient.clone(),
+            10,
+            Token::default(),
+            timestamp
+        )
+        .await
+        .map_err(|err| {
+            eprintln!("Unable to send transaction: {}", err);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    telemetry::info!("Sent faucet drip to: {:?}", recipient.to_string());
+
+    Ok(Json::from(digest))
+}
+
+impl Faucet {
+    pub async fn new(config: FaucetConfig) -> Result<Self, WalletError> {
+
+        let wallet = Wallet::restore_from_private_key(
+            config.secret_key.clone(),
+            config.rpc_server_address,
+        ).await?;
+
+        println!("Wallet restored from private key, Address: {:?}", wallet.address.to_string());
+
+        let faucet = Faucet {
+            config,
+            wallet: Arc::new(Mutex::new(wallet)),
+        };
+
+        Ok(faucet)
+    }
+    pub async fn start(self) -> Result<(), axum::Error> {
+
+        let app = Router::new()
+            .route("/drip", post(drip))
+            .layer(Extension(self.wallet));
+
+        let addr = SocketAddr::from(([127, 0, 0, 1], self.config.server_port));
+        println!("Server started at http://{}", addr);
+        axum::Server::bind(&addr).serve(app.into_make_service()).await.unwrap();
+
+        Ok(())
+    }
+}

--- a/crates/faucet/src/lib.rs
+++ b/crates/faucet/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod faucet;

--- a/crates/vrrb_core/src/transactions/transfer.rs
+++ b/crates/vrrb_core/src/transactions/transfer.rs
@@ -117,6 +117,19 @@ impl TransferBuilder {
         self.signature = Some(signature);
         self
     }
+    pub fn build_payload(&self) -> String {
+        format!(
+            "{:x}",
+            hash_data!(
+                self.sender_address.clone(),
+                self.sender_public_key.clone(),
+                self.receiver_address.clone(),
+                self.token.clone(),
+                self.amount.clone(),
+                self.nonce.clone()
+            )
+        )
+    }
 
     pub fn validators(mut self, validators: HashMap<String, bool>) -> Self {
         self.validators = Some(validators);

--- a/crates/wallet/src/v2/mod.rs
+++ b/crates/wallet/src/v2/mod.rs
@@ -163,29 +163,19 @@ impl Wallet {
         //     }
         // };
 
-        let payload = utils::hash_data!(
-            timestamp,
-            sender_address.to_string(),
-            self.public_key.to_string(),
-            receiver.to_string(),
-            amount,
-            token,
-            self.nonce.clone()
-        );
-
-        let signature = self.sign_transaction(&payload[..]);
-
-        let transfer = TransactionKind::transfer_builder()
+        let transfer_builder = TransactionKind::transfer_builder()
             .timestamp(timestamp)
             .sender_address(sender_address)
             .sender_public_key(self.public_key)
             .receiver_address(receiver)
             .token(token)
             .amount(amount)
-            .signature(signature)
             .validators(HashMap::new())
-            .nonce(self.nonce)
-            .build_kind()
+            .nonce(self.nonce);
+
+        let signature = self.sign_transaction(transfer_builder.build_payload().as_bytes());
+
+        let transfer = transfer_builder.signature(signature).build_kind()
             .map_err(|_| WalletError::Custom("Failed to build transfer transaction".to_string()))?;
 
         self


### PR DESCRIPTION
This also includes the code to move the payload_builder implementation from wallet/transfer into transfer_builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `Faucet` command to the CLI, allowing users to start a faucet server for token distribution.
  - Implemented a `Faucet` service with an HTTP endpoint for processing token transfer requests to user accounts.

- **Enhancements**
  - Streamlined the transaction creation and signature process within the wallet module using a new `transfer_builder`.

- **Documentation**
  - Updated CLI documentation to include information on the new `Faucet` command and its options.

Please note that these release notes are a high-level summary and do not include specific code-level details to maintain confidentiality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->