### PR TITLE
add rust-analyzer component to `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.74.0"
+components = [ "rust-analyzer" ]
 


### PR DESCRIPTION
Closes #718 