### PR TITLE
Add `internal_rpc` client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,6 +3202,7 @@ dependencies = [
  "platform",
  "serde",
  "service_config",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/internal_rpc/Cargo.toml
+++ b/crates/internal_rpc/Cargo.toml
@@ -11,3 +11,4 @@ jsonrpsee = { workspace = true }
 platform = { workspace = true }
 serde = { workspace = true }
 service_config = { workspace = true }
+tokio = { workspace = true }

--- a/crates/internal_rpc/src/client.rs
+++ b/crates/internal_rpc/src/client.rs
@@ -1,32 +1,34 @@
 use crate::api::RpcResult;
+use jsonrpsee::core::client::Client;
 use jsonrpsee::ws_client::WsClientBuilder;
+use std::net::SocketAddr;
 
-// Stub for the client request cli
-#[derive(Debug)]
-pub struct ClientRequest;
+/// The websocket internal RPC client used for
+/// requesting services and obtaining responses
+/// from the `InternalRpcServer`.
+///
+/// To interact with the server, use the methods
+/// available on the `InternalRpcApi` interface.
+pub struct InternalRpcClient(pub Client);
+impl InternalRpcClient {
+    /// Accepts a URL to a server, and attempts to build a client bound to that URL.
+    /// The URL to the server MUST include the port.
+    pub async fn new(socket: &SocketAddr) -> RpcResult<Self> {
+        let client = WsClientBuilder::default()
+            .build(format!("ws://{socket}"))
+            .await?;
 
-async fn _run(request_opts: ClientRequest, server_url_with_port: &str) -> RpcResult<()> {
-    // Connect to the JSON-RPC server using WebSocket
-    let client = WsClientBuilder::default()
-        .build(&server_url_with_port)
-        .await?;
-
-    // Example: Call a JSON-RPC method
-    // This will be where we make requests from the server
-    // after establishing a connection
-    if client.is_connected() {
-        println!("connection to server established");
-        dbg!(&request_opts);
-        Ok(())
-    } else {
-        Err(jsonrpsee::core::Error::Custom(format!(
-            "failed to establish connection to server at {}",
-            server_url_with_port
-        )))
+        if client.is_connected() {
+            println!("connection to server established");
+            Ok(InternalRpcClient(client))
+        } else {
+            Err(jsonrpsee::core::Error::Custom(format!(
+                "failed to establish connection to server at {}",
+                socket
+            )))
+        }
     }
-}
-
-#[tokio::test]
-async fn test_client() {
-    assert!(_run(ClientRequest, "wss://localhost:443").await.is_ok());
+    pub fn is_connected(&self) -> bool {
+        self.0.is_connected()
+    }
 }

--- a/crates/internal_rpc/src/client.rs
+++ b/crates/internal_rpc/src/client.rs
@@ -1,0 +1,32 @@
+use crate::api::RpcResult;
+use jsonrpsee::ws_client::WsClientBuilder;
+
+// Stub for the client request cli
+#[derive(Debug)]
+pub struct ClientRequest;
+
+async fn _run(request_opts: ClientRequest, server_url_with_port: &str) -> RpcResult<()> {
+    // Connect to the JSON-RPC server using WebSocket
+    let client = WsClientBuilder::default()
+        .build(&server_url_with_port)
+        .await?;
+
+    // Example: Call a JSON-RPC method
+    // This will be where we make requests from the server
+    // after establishing a connection
+    if client.is_connected() {
+        println!("connection to server established");
+        dbg!(&request_opts);
+        Ok(())
+    } else {
+        Err(jsonrpsee::core::Error::Custom(format!(
+            "failed to establish connection to server at {}",
+            server_url_with_port
+        )))
+    }
+}
+
+#[tokio::test]
+async fn test_client() {
+    assert!(_run(ClientRequest, "wss://localhost:443").await.is_ok());
+}

--- a/crates/internal_rpc/src/lib.rs
+++ b/crates/internal_rpc/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod api;
+pub mod client;
 pub mod server;

--- a/crates/internal_rpc/src/lib.rs
+++ b/crates/internal_rpc/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod api;
 pub mod client;
 pub mod server;
+mod tests;

--- a/crates/internal_rpc/src/tests/mod.rs
+++ b/crates/internal_rpc/src/tests/mod.rs
@@ -1,0 +1,44 @@
+#![cfg(test)]
+use service_config::ServiceConfig;
+
+use crate::{client::InternalRpcClient, server::InternalRpcServer};
+
+fn test_service_config() -> ServiceConfig {
+    ServiceConfig {
+        name: "test_service".into(),
+        rpc_address: "127.0.0.1".into(),
+        rpc_port: 8080,
+        pre_shared_key: "test".into(),
+        tls_private_key_file: "test".into(),
+        tls_public_cert_file: "test".into(),
+        tls_ca_cert_file: "test".into(),
+        exporter_address: "test".into(),
+        exporter_port: "test".into(),
+    }
+}
+
+#[tokio::test]
+async fn test_start_server() {
+    let (handle, _socket) = InternalRpcServer::start(
+        &test_service_config(),
+        platform::services::ServiceType::Compute,
+    )
+    .await
+    .unwrap();
+    assert!(handle.stop().is_ok());
+    assert!(handle.is_stopped());
+}
+
+#[tokio::test]
+async fn test_client_connection_to_server() {
+    let (handle, socket) = InternalRpcServer::start(
+        &test_service_config(),
+        platform::services::ServiceType::Compute,
+    )
+    .await
+    .unwrap();
+    let client = InternalRpcClient::new(&socket).await.unwrap();
+    assert!(client.is_connected());
+    handle.stop().unwrap();
+    assert!(handle.is_stopped());
+}


### PR DESCRIPTION
Ref #519 
Closes #712 

Adds a new type, `InternalRpcClient`, helper methods and tests.