### PR TITLE
Address remaining clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
 dependencies = [
  "concurrent-queue",
  "event-listener 4.0.0",
- "event-listener-strategy",
+ "event-listener-strategy 0.4.0",
  "futures-core",
  "pin-project-lite",
 ]
@@ -225,11 +225,11 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 2.8.0",
+ "async-lock 3.1.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 1.13.0",
+ "futures-lite 2.1.0",
  "slab",
 ]
 
@@ -253,10 +253,10 @@ checksum = "9b4353121d5644cdf2beb5726ab752e79a8db1ebb52031770ec47db31d245526"
 dependencies = [
  "async-channel 2.1.1",
  "async-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-io 2.2.1",
+ "async-lock 3.1.0",
  "blocking",
- "futures-lite 1.13.0",
+ "futures-lite 2.1.0",
  "once_cell",
  "tokio",
 ]
@@ -293,7 +293,7 @@ dependencies = [
  "futures-io",
  "futures-lite 2.1.0",
  "parking",
- "polling 3.3.0",
+ "polling 3.3.1",
  "rustix 0.38.21",
  "slab",
  "tracing",
@@ -315,8 +315,8 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb2ab2aa8a746e221ab826c73f48bc6ba41be6763f0855cb249eb6d154cf1d7"
 dependencies = [
- "event-listener 4.0.0",
- "event-listener-strategy",
+ "event-listener 3.1.0",
+ "event-listener-strategy 0.3.0",
  "pin-project-lite",
 ]
 
@@ -768,7 +768,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
- "async-channel 2.1.0",
+ "async-channel 2.1.1",
  "async-lock 3.1.0",
  "async-task",
  "fastrand 2.0.1",
@@ -2193,6 +2193,16 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96b852f1345da36d551b9473fa1e2b1eb5c5195585c6c018118bc92a8d91160"
+dependencies = [
+ "event-listener 3.1.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
@@ -2489,6 +2499,8 @@ checksum = "aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
+ "futures-io",
+ "parking",
  "pin-project-lite",
 ]
 
@@ -5761,7 +5773,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.11",
+ "linux-raw-sys 0.4.12",
  "windows-sys 0.48.0",
 ]
 

--- a/crates/block/src/header.rs
+++ b/crates/block/src/header.rs
@@ -8,7 +8,7 @@ use secp256k1::{
     Message,
 };
 use serde::{Deserialize, Serialize};
-use utils::{create_payload, hash_data, payload::digest_data_to_bytes};
+use utils::{create_payload, hash_data};
 use vrrb_core::claim::Claim;
 use vrrb_vrf::{vrng::VRNG, vvrf::VVRF};
 
@@ -84,13 +84,13 @@ pub fn genesis_block_header_hashed_payload(
         next_block_reward,
     );
 
-    Message::from(secp256k1::hashes::sha256::Hash::hash(&hashed.as_bytes()))
+    Message::from(secp256k1::hashes::sha256::Hash::hash(hashed.as_bytes()))
 }
 
 impl BlockHeader {
     //TODO: miners needs to wait on threshold signature before passing to this fxn
     pub fn genesis(
-        seed: u64,
+        _seed: u64,
         round: u128,
         epoch: Epoch,
         miner_claim: Claim,

--- a/crates/cli/src/commands/dev/run.rs
+++ b/crates/cli/src/commands/dev/run.rs
@@ -1,21 +1,19 @@
 use config::{Config, ConfigError, File};
 use node::test_utils::create_test_network_from_config;
-use node::Node;
-use primitives::{
-    Address, KademliaPeerId, NodeId, NodeType, DEFAULT_VRRB_DATA_DIR_PATH, DEFAULT_VRRB_DB_PATH,
-};
+
+use primitives::{Address, NodeType, DEFAULT_VRRB_DATA_DIR_PATH, DEFAULT_VRRB_DB_PATH};
 use secp256k1::PublicKey;
 use serde::Deserialize;
-use serde_json::{from_str as json_from_str, from_value as json_from_value, Value as JsonValue};
+
 use std::str::FromStr;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
 };
 use telemetry::{error, info};
-use utils::payload::digest_data_to_bytes;
+
 use uuid::Uuid;
-use vrrb_config::{BootstrapConfig, NodeConfig, QuorumMember};
+use vrrb_config::{BootstrapConfig, NodeConfig};
 
 use crate::{
     commands::{
@@ -308,14 +306,14 @@ pub async fn run(args: RunOpts) -> Result<()> {
     // TODO: prevent parsing errors when no kademlia peer id is present
     let mut whitelisted_nodes = args
         .whitelist_path
-        .and_then(|whitelist| {
+        .map(|whitelist| {
             let mut finalized_whitelist = Vec::with_capacity(GENESIS_QUORUM_SIZE);
             if let Err(e) =
                 deserialize_whitelisted_quorum_members(whitelist, &mut finalized_whitelist)
             {
                 error!("failed to deserialize whitelist: {e}");
             }
-            Some(finalized_whitelist)
+            finalized_whitelist
         })
         .unwrap_or_default();
 

--- a/crates/cli/src/commands/faucet/mod.rs
+++ b/crates/cli/src/commands/faucet/mod.rs
@@ -32,9 +32,7 @@ pub struct FaucetOpts {
 }
 
 pub async fn exec(args: FaucetOpts) -> Result<()> {
-    let sub_cmd = args.subcommand;
-
-    match sub_cmd {
+    match args.subcommand {
         FaucetCmd::Run => {
             let config = FaucetConfig {
                 rpc_server_address: args.rpc_server_address,
@@ -57,6 +55,5 @@ pub async fn exec(args: FaucetOpts) -> Result<()> {
                 Err(CliError::Other("Failed to create faucet".to_string()))
             }
         }
-        _ => Err(CliError::InvalidCommand(format!("{sub_cmd:?}"))),
     }
 }

--- a/crates/cli/src/commands/faucet/mod.rs
+++ b/crates/cli/src/commands/faucet/mod.rs
@@ -1,12 +1,7 @@
-use std::{collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr};
+use std::net::SocketAddr;
 
 use clap::{Parser, Subcommand};
 use faucet::faucet::{Faucet, FaucetConfig};
-use primitives::Address;
-use serde_json;
-use vrrb_core::transactions::Token;
-use vrrb_core::{account::Account, helpers::read_or_generate_keypair_file};
-use wallet::v2::{AddressAlias, Wallet, WalletConfig};
 
 use crate::result::{CliError, Result};
 

--- a/crates/cli/src/commands/node/run.rs
+++ b/crates/cli/src/commands/node/run.rs
@@ -1,18 +1,16 @@
 use config::{Config, ConfigError, File};
 use node::Node;
-use primitives::{
-    KademliaPeerId, NodeId, NodeType, DEFAULT_VRRB_DATA_DIR_PATH, DEFAULT_VRRB_DB_PATH,
-};
+use primitives::{NodeType, DEFAULT_VRRB_DATA_DIR_PATH, DEFAULT_VRRB_DB_PATH};
 use serde::Deserialize;
-use serde_json::{from_str as json_from_str, from_value as json_from_value, Value as JsonValue};
+
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
 };
 use telemetry::{error, info};
-use utils::payload::digest_data_to_bytes;
+
 use uuid::Uuid;
-use vrrb_config::{NodeConfig, QuorumMember};
+use vrrb_config::NodeConfig;
 
 use crate::{
     commands::{
@@ -283,14 +281,14 @@ pub async fn run(args: RunOpts) -> Result<()> {
     // TODO: prevent parsing errors when no kademlia peer id is present
     let mut whitelisted_nodes = args
         .whitelist_path
-        .and_then(|whitelist| {
+        .map(|whitelist| {
             let mut finalized_whitelist = Vec::with_capacity(GENESIS_QUORUM_SIZE);
             if let Err(e) =
                 deserialize_whitelisted_quorum_members(whitelist, &mut finalized_whitelist)
             {
                 error!("failed to deserialize whitelist: {e}");
             }
-            Some(finalized_whitelist)
+            finalized_whitelist
         })
         .unwrap_or_default();
 

--- a/crates/cli/src/commands/wallet/new.rs
+++ b/crates/cli/src/commands/wallet/new.rs
@@ -4,7 +4,6 @@ use primitives::Address;
 use secp256k1::{generate_keypair, rand};
 use vrrb_core::account::Account;
 use vrrb_core::helpers::write_keypair_file;
-use wallet::v2::{AddressAlias, Wallet};
 
 use crate::result::CliError;
 
@@ -16,7 +15,7 @@ pub async fn exec(
 
     let (secret_key, public_key) = generate_keypair(&mut rand::thread_rng());
 
-    let account_data_dir = path.join(format!("account"));
+    let account_data_dir = path.join("account");
     // let account_data_dir = path.join(format!("{alias}"));
 
     std::fs::create_dir_all(&account_data_dir)?;

--- a/crates/consensus/job_scheduler/src/lib.rs
+++ b/crates/consensus/job_scheduler/src/lib.rs
@@ -87,21 +87,21 @@ impl JobScheduler {
                 cores_allocation.0,
                 cores_allocation.0 + 4,
             )
-            .unwrap_or(PoolBuilder::default())
+            .unwrap_or_default()
             .stack_size(2 * 1024 * 1024)
             .build(),
             remote_pool: PoolBuilder::with_workers_capacity(
                 cores_allocation.1,
                 cores_allocation.1 + 4,
             )
-            .unwrap_or(PoolBuilder::default())
+            .unwrap_or_default()
             .stack_size(2 * 1024 * 1024)
             .build(),
             forwarding_pool: PoolBuilder::with_workers_capacity(
                 cores_allocation.2,
                 cores_allocation.2 + 2,
             )
-            .unwrap_or(PoolBuilder::default())
+            .unwrap_or_default()
             .stack_size(2 * 1024 * 1024)
             .build(),
             peers_back_pressure: Cache::new(1000, 50000),

--- a/crates/consensus/signer/src/engine.rs
+++ b/crates/consensus/signer/src/engine.rs
@@ -204,7 +204,7 @@ impl SignerEngine {
 
     pub fn verify_batch<T: AsRef<[u8]> + std::fmt::Debug>(
         &self,
-        batch_sigs: &Vec<(NodeId, Signature)>,
+        batch_sigs: &[(NodeId, Signature)],
         data: &T,
     ) -> Result<(), Error> {
         let errs = batch_sigs

--- a/crates/faucet/src/faucet.rs
+++ b/crates/faucet/src/faucet.rs
@@ -3,14 +3,14 @@ use axum::{http::StatusCode, Extension, Json, Router};
 use axum::routing::post;
 use primitives::Address;
 use serde::Deserialize;
-use serde_json::json;
+
+use std::net::SocketAddr;
 use std::sync::Arc;
-use std::{convert::Infallible, net::SocketAddr};
 use telemetry::error;
-use tokio::spawn;
+
 use tokio::sync::Mutex;
 use vrrb_core::transactions::{RpcTransactionDigest, Token};
-use wallet::v2::{Wallet, WalletConfig, WalletError};
+use wallet::v2::{Wallet, WalletError};
 
 #[derive(Deserialize)]
 struct FaucetRequest {

--- a/crates/metric_exporter/src/metric_factory.rs
+++ b/crates/metric_exporter/src/metric_factory.rs
@@ -359,8 +359,8 @@ impl PrometheusFactory {
                     info!("Received SIGHUP,reloading server with new certificate");
                     continue;
                 }
+                return Ok(());
             }
-            Ok(())
         }
     }
 }

--- a/crates/node/src/consensus/consensus_module.rs
+++ b/crates/node/src/consensus/consensus_module.rs
@@ -360,7 +360,7 @@ impl ConsensusModule {
         let set = self.get_quorum_pending_votes_for_transaction(quorum_id, vote)?;
         let quorum_members = self.get_quorum_members(quorum_id)?;
         if self.double_check_vote_threshold_reached(&set, quorum_members) {
-            let batch_sigs = set
+            let batch_sigs: Vec<(String, Signature)> = set
                 .iter()
                 .map(|vote| (vote.farmer_node_id.clone(), vote.signature))
                 .collect();

--- a/crates/node/src/consensus/consensus_module.rs
+++ b/crates/node/src/consensus/consensus_module.rs
@@ -491,12 +491,9 @@ impl ConsensusModule {
         self.is_harvester()?;
 
         if let Some((quorum_id, QuorumKind::Farmer)) = self.get_node_quorum_id(&vote.farmer_id) {
-            let nested_map = self
-                .votes_pool
-                .entry(quorum_id)
-                .or_insert_with(HashMap::new);
+            let nested_map = self.votes_pool.entry(quorum_id).or_default();
             let digest = vote.txn.id();
-            let vote_set = nested_map.entry(digest).or_insert_with(HashSet::new);
+            let vote_set = nested_map.entry(digest).or_default();
             vote_set.insert(vote);
             return Ok(());
         }
@@ -561,7 +558,7 @@ impl ConsensusModule {
         for v in votes.iter() {
             vote_shares
                 .entry(v.is_txn_valid)
-                .or_insert_with(BTreeMap::new)
+                .or_default()
                 .insert(v.farmer_node_id.clone(), v.signature);
         }
 

--- a/crates/node/src/consensus/quorum_module.rs
+++ b/crates/node/src/consensus/quorum_module.rs
@@ -9,7 +9,7 @@ use quorum::{
     quorum::{Quorum, QuorumError},
 };
 use theater::{ActorId, ActorState};
-use vrrb_config::{BootstrapConfig, BootstrapQuorumConfig, NodeConfig, QuorumMembershipConfig};
+use vrrb_config::{BootstrapConfig, NodeConfig, QuorumMembershipConfig};
 use vrrb_core::claim::{Claim, Eligibility};
 
 #[derive(Debug, Clone)]

--- a/crates/node/src/network/component.rs
+++ b/crates/node/src/network/component.rs
@@ -6,7 +6,7 @@ use primitives::{KademliaPeerId, NodeId, PublicKey};
 use storage::vrrbdb::VrrbDbReadHandle;
 use telemetry::info;
 use theater::{Actor, ActorImpl, Handler};
-use vrrb_config::{BootstrapQuorumConfig, NodeConfig, QuorumMembershipConfig};
+use vrrb_config::{NodeConfig, QuorumMembershipConfig};
 
 use crate::{NodeError, RuntimeComponent, RuntimeComponentHandle};
 

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -1147,12 +1147,13 @@ mod tests {
         let votes: Vec<Vote> = farmers
             .iter_mut()
             .map(|nr| {
-                nr.handle_create_account_requested(sender_address.clone(), account_bytes.clone());
-                nr.insert_txn_to_mempool(txn.clone());
+                let _ = nr
+                    .handle_create_account_requested(sender_address.clone(), account_bytes.clone());
+                let _ = nr.insert_txn_to_mempool(txn.clone());
                 let mempool_reader = nr.mempool_read_handle_factory();
                 let state_reader = nr.state_store_read_handle_factory();
                 let res = nr
-                    .validate_transaction_kind(txn.digest(), mempool_reader, state_reader)
+                    .validate_transaction_kind(txn.id(), mempool_reader, state_reader)
                     .unwrap();
                 nr.cast_vote_on_transaction_kind(res.0, res.1).unwrap()
             })

--- a/crates/node/src/runtime/mod.rs
+++ b/crates/node/src/runtime/mod.rs
@@ -79,7 +79,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn bootstrap_node_runtime_can_assign_quorum_memberships_to_available_nodes() {
-        let (node_0, farmers, harvesters, miners) = setup_network(8).await;
+        let (_node_0, farmers, harvesters, _miners) = setup_network(8).await;
 
         assert_eq!(farmers.len(), 4);
         assert_eq!(harvesters.len(), 2);
@@ -277,7 +277,7 @@ mod tests {
         let (_, public_key) = generate_account_keypair();
         let receiver_address = node_0.create_account(public_key).unwrap();
 
-        let txn = create_txn_from_accounts(
+        let _txn = create_txn_from_accounts(
             (sender_address, Some(sender_account)),
             receiver_address,
             vec![],
@@ -308,7 +308,7 @@ mod tests {
 
         for (_, harvester) in harvesters.iter_mut() {
             let sig_engine = harvester.consensus_driver.sig_engine.clone();
-            let proposal_block = harvester
+            let _proposal_block = harvester
                 .mine_proposal_block(
                     genesis_block.hash.clone(),
                     Default::default(), // TODO: change to an actual map of harvester claims
@@ -374,7 +374,7 @@ mod tests {
     #[serial_test::serial]
     #[ignore = "https://github.com/versatus/versatus/issues/488"]
     async fn harvester_node_runtime_can_handle_convergence_block_created() {
-        let (mut node_0, farmers, mut harvesters, mut miners) = setup_network(8).await;
+        let (node_0, farmers, mut harvesters, mut miners) = setup_network(8).await;
         let receiver = GenesisReceiver(Address::new(
             farmers
                 .iter()
@@ -395,7 +395,7 @@ mod tests {
 
         let miner_id = miner_ids.first().unwrap();
 
-        let mut miner_node = miners.get_mut(miner_id).unwrap();
+        let miner_node = miners.get_mut(miner_id).unwrap();
 
         let genesis_block = miner_node.mine_genesis_block(genesis_rewards).unwrap();
 
@@ -455,7 +455,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "broken atm"]
     async fn node_runtime_can_form_quorum_with_valid_config() {
-        let (mut node_0, farmers, harvesters, miners) = setup_network(8).await;
+        let (_node_0, _farmers, _harvesters, _miners) = setup_network(8).await;
 
         // let res = node_0.generate_partial_commitment_message();
         // assert!(res.is_err(), "bootstrap nodes cannot participate in DKG");
@@ -601,7 +601,7 @@ mod tests {
             vec![],
         );
 
-        for farmer in farmer_nodes.iter() {
+        for _farmer in farmer_nodes.iter() {
             // dbg!(&farmer.consensus_driver.quorum_driver.node_config.node_type);
             // dbg!(&farmer.consensus_driver.is_farmer());
         }

--- a/crates/node/src/state_manager/mod.rs
+++ b/crates/node/src/state_manager/mod.rs
@@ -15,17 +15,16 @@ mod tests {
 
     use block::{Block, BlockHash};
     use bulldag::{graph::BullDag, vertex::Vertex};
-    use integral_db::LeftRightTrie;
+
     use mempool::LeftRightMempool;
     use miner::test_helpers::{create_address, create_claim};
     use primitives::Address;
     use serial_test::serial;
     use signer::engine::SignerEngine;
-    use storage::vrrbdb::types::*;
-    use storage::vrrbdb::{RocksDbAdapter, VrrbDb, VrrbDbConfig};
-    use storage::{storage_utils::remove_vrrb_data_dir, vrrbdb::types::*};
-    use theater::{Actor, ActorImpl, ActorState, Handler};
-    use tokio::sync::mpsc::channel;
+
+    use storage::storage_utils::remove_vrrb_data_dir;
+    use storage::vrrbdb::{VrrbDb, VrrbDbConfig};
+
     use vrrb_core::transactions::TransactionKind;
     use vrrb_core::{account::Account, claim::Claim, keypair::KeyPair};
 

--- a/crates/node/src/test_utils/mock_config.rs
+++ b/crates/node/src/test_utils/mock_config.rs
@@ -1,42 +1,15 @@
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, HashMap, HashSet, VecDeque},
     env,
-    hash::{Hash, Hasher},
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::{Arc, RwLock},
     time::Duration,
 };
 
-use block::{
-    header::BlockHeader, Block, BlockHash, ConvergenceBlock, GenesisBlock, InnerBlock,
-    ProposalBlock,
-};
-use bulldag::{graph::BullDag, vertex::Vertex};
-use quorum::{election::Election, quorum::Quorum};
-
-use crate::{network::NetworkEvent, node_runtime::NodeRuntime, Node, Result};
-use events::{AssignedQuorumMembership, EventPublisher, PeerData, DEFAULT_BUFFER};
 pub use miner::test_helpers::{create_address, create_claim, create_miner};
-use primitives::{generate_account_keypair, Address, KademliaPeerId, NodeId, NodeType, QuorumKind};
-use rand::{seq::SliceRandom, thread_rng};
-use secp256k1::{Message, PublicKey, SecretKey};
-use sha256::digest;
-use signer::engine::SignerEngine;
+use primitives::{KademliaPeerId, NodeType};
+
 use uuid::Uuid;
-use vrrb_config::{
-    BootstrapQuorumConfig, NodeConfig, NodeConfigBuilder, QuorumMember, QuorumMembershipConfig,
-    ThresholdConfig,
-};
-use vrrb_core::{
-    account::{Account, AccountField},
-    claim::Claim,
-    keypair::{KeyPair, Keypair},
-    transactions::{
-        generate_transfer_digest_vec, NewTransferArgs, Transaction, TransactionDigest,
-        TransactionKind, Transfer,
-    },
-};
-use vrrb_rpc::rpc::{api::RpcApiClient, client::create_client};
+use vrrb_config::{NodeConfig, NodeConfigBuilder, ThresholdConfig};
+use vrrb_core::keypair::Keypair;
 
 pub fn create_mock_full_node_config() -> NodeConfig {
     let data_dir = env::temp_dir();

--- a/crates/node/src/test_utils/mod.rs
+++ b/crates/node/src/test_utils/mod.rs
@@ -1,10 +1,8 @@
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, HashMap, HashSet, VecDeque},
-    env,
+    collections::{hash_map::DefaultHasher, HashMap, HashSet, VecDeque},
     hash::{Hash, Hasher},
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::SocketAddr,
     sync::{Arc, RwLock},
-    time::Duration,
 };
 
 use block::{
@@ -14,22 +12,19 @@ use block::{
 use bulldag::{graph::BullDag, vertex::Vertex};
 use quorum::{election::Election, quorum::Quorum};
 
-use crate::{network::NetworkEvent, node_runtime::NodeRuntime, Node, Result};
-use events::{AssignedQuorumMembership, EventPublisher, PeerData, DEFAULT_BUFFER};
+use crate::{network::NetworkEvent, node_runtime::NodeRuntime, Result};
+use events::{AssignedQuorumMembership, PeerData, DEFAULT_BUFFER};
 pub use miner::test_helpers::{create_address, create_claim, create_miner};
 pub use mock_config::*;
 pub use node_network::*;
-use primitives::{generate_account_keypair, Address, KademliaPeerId, NodeId, NodeType, QuorumKind};
+use primitives::{generate_account_keypair, Address, NodeId, NodeType, QuorumKind};
 use rand::{seq::SliceRandom, thread_rng};
 pub use runtime_network::*;
 use secp256k1::{Message, PublicKey, SecretKey};
 use sha256::digest;
 use signer::engine::SignerEngine;
-use uuid::Uuid;
-use vrrb_config::{
-    BootstrapQuorumConfig, NodeConfig, NodeConfigBuilder, QuorumMember, QuorumMembershipConfig,
-    ThresholdConfig,
-};
+
+use vrrb_config::QuorumMember;
 use vrrb_core::{
     account::{Account, AccountField},
     claim::Claim,

--- a/crates/node/src/test_utils/node_network.rs
+++ b/crates/node/src/test_utils/node_network.rs
@@ -1,42 +1,18 @@
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, HashMap, HashSet, VecDeque},
-    env,
-    hash::{Hash, Hasher},
+    collections::{BTreeMap, HashMap},
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::{Arc, RwLock},
-    time::Duration,
 };
 
-use block::{
-    header::BlockHeader, Block, BlockHash, ConvergenceBlock, GenesisBlock, InnerBlock,
-    ProposalBlock,
-};
-use bulldag::{graph::BullDag, vertex::Vertex};
-use quorum::{election::Election, quorum::Quorum};
+use crate::Node;
 
-use crate::{network::NetworkEvent, node_runtime::NodeRuntime, Node, Result};
-use events::{AssignedQuorumMembership, EventPublisher, PeerData, DEFAULT_BUFFER};
 pub use miner::test_helpers::{create_address, create_claim, create_miner};
-use primitives::{generate_account_keypair, Address, KademliaPeerId, NodeId, NodeType, QuorumKind};
-use rand::{seq::SliceRandom, thread_rng};
-use secp256k1::{Message, PublicKey, SecretKey};
-use sha256::digest;
-use signer::engine::SignerEngine;
-use uuid::Uuid;
+use primitives::{KademliaPeerId, NodeId, NodeType, QuorumKind};
+
 use vrrb_config::{
     BootstrapConfig, BootstrapPeerData, BootstrapQuorumConfig, BootstrapQuorumMember, NodeConfig,
-    NodeConfigBuilder, QuorumMember, QuorumMembershipConfig, ThresholdConfig,
+    QuorumMember,
 };
-use vrrb_core::{
-    account::{Account, AccountField},
-    claim::Claim,
-    keypair::{KeyPair, Keypair},
-    transactions::{
-        generate_transfer_digest_vec, NewTransferArgs, Transaction, TransactionDigest,
-        TransactionKind, Transfer,
-    },
-};
-use vrrb_rpc::rpc::{api::RpcApiClient, client::create_client};
+use vrrb_core::keypair::Keypair;
 
 use super::create_mock_full_node_config;
 
@@ -119,7 +95,7 @@ pub async fn create_test_network_from_config(n: u16, base_config: Option<NodeCon
 
     let node_0 = Node::start(config).await.unwrap();
 
-    let mut bootstrap_peer_data = BootstrapPeerData {
+    let bootstrap_peer_data = BootstrapPeerData {
         id: node_0.kademlia_peer_id(),
         udp_gossip_addr: node_0.udp_gossip_address(),
         raptorq_gossip_addr: node_0.raptorq_gossip_address(),

--- a/crates/node/src/test_utils/node_network.rs
+++ b/crates/node/src/test_utils/node_network.rs
@@ -84,9 +84,10 @@ pub async fn create_test_network_from_config(n: u16, base_config: Option<NodeCon
         None
     };
 
-    let mut bootstrap_config = BootstrapConfig::default();
-    bootstrap_config.additional_genesis_receivers = additional_genesis_receivers;
-    bootstrap_config.bootstrap_quorum_config = bootstrap_quorum_config.clone();
+    let bootstrap_config = BootstrapConfig {
+        additional_genesis_receivers,
+        bootstrap_quorum_config: bootstrap_quorum_config.clone(),
+    };
 
     let mut config = create_mock_full_node_config();
     config.id = String::from("node-0");

--- a/crates/node/tests/startup.rs
+++ b/crates/node/tests/startup.rs
@@ -1,7 +1,4 @@
-use node::{
-    test_utils::{create_mock_bootstrap_node_config, create_mock_full_node_config_with_bootstrap},
-    Node,
-};
+use node::{test_utils::create_mock_bootstrap_node_config, Node};
 use primitives::node::NodeType;
 use serial_test::serial;
 use storage::storage_utils::remove_vrrb_data_dir;

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,5 +1,5 @@
 use secp256k1::{rand::rngs::OsRng, Secp256k1};
-use serde::{Deserialize, Serialize};
+use serde;
 use sha2::Digest;
 use sha3::Keccak256;
 use std::str::FromStr;

--- a/crates/storage/vrrbdb/src/vrrbdb.rs
+++ b/crates/storage/vrrbdb/src/vrrbdb.rs
@@ -4,7 +4,7 @@ use block::{Block, ConvergenceBlock, GenesisBlock, GenesisRewards, ProposalBlock
 use ethereum_types::U256;
 use patriecia::RootHash;
 use primitives::Address;
-use ritelinked::LinkedHashMap;
+
 use storage_utils::{Result, StorageError};
 use vrrb_core::transactions::{Transaction, TransactionKind, Transfer};
 use vrrb_core::{
@@ -353,12 +353,12 @@ impl VrrbDb {
     pub fn apply_block(&mut self, block: Block) -> Result<ApplyBlockResult> {
         match block {
             Block::Genesis { block } => self.apply_genesis_block(block),
-            Block::Convergence { block } => {
+            Block::Convergence { block: _ } => {
                 todo!()
             }
             _ => {
                 telemetry::info!("unsupported block type: {:?}", block);
-                return Err(StorageError::Other("unsupported block type".to_string()));
+                Err(StorageError::Other("unsupported block type".to_string()))
             }
         }
     }

--- a/crates/vrrb_core/src/account.rs
+++ b/crates/vrrb_core/src/account.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use primitives::Address;
-use ritelinked::LinkedHashMap;
+
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -264,8 +264,8 @@ impl RpcApiServer for RpcServerImpl {
 
         let claims = claims
             .values()
+            .filter(|&claim| claim.address == address)
             .cloned()
-            .filter(|claim| claim.address == address)
             .collect();
 
         Ok(claims)
@@ -290,8 +290,8 @@ impl RpcApiServer for RpcServerImpl {
 
         let claims = claims
             .values()
+            .filter(|&claim| claim_hashes.contains(&claim.hash))
             .cloned()
-            .filter(|claim| claim_hashes.contains(&claim.hash))
             .collect();
 
         Ok(claims)

--- a/crates/vrrb_rpc/tests/http.rs
+++ b/crates/vrrb_rpc/tests/http.rs
@@ -1,6 +1,6 @@
 use crate::{HttpApiServer, HttpApiServerConfig, HttpApiServerConfigBuilder};
 use axum::{body::Body, http::Request};
-use axum_server::tls_rustls::RustlsConfig;
+
 use events::Event;
 use hyper::{Client, StatusCode};
 use tokio::sync::broadcast::channel;

--- a/crates/wallet/tests/wallet_rpc_tests.rs
+++ b/crates/wallet/tests/wallet_rpc_tests.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use primitives::Address;
-use secp256k1::{generate_keypair, PublicKey, Secp256k1, SecretKey};
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
 use serial_test::serial;
 use storage::storage_utils::remove_vrrb_data_dir;
 use tokio::sync::mpsc::channel;

--- a/crates/wasm_runtime/src/errors.rs
+++ b/crates/wasm_runtime/src/errors.rs
@@ -73,14 +73,11 @@ impl WasmRuntimeError {
         None
     }
     pub fn inst_err(&self) -> Option<String> {
-        if let WasmRuntimeError::InstantiationError(inst_err) = self {
-            match inst_err {
-                InstantiationError::Link(link_err) => match link_err {
-                    wasmer::LinkError::Resource(s) => Some(s.clone()),
-                    _ => None,
-                },
-                _ => None,
-            }
+        if let WasmRuntimeError::InstantiationError(InstantiationError::Link(
+            wasmer::LinkError::Resource(s),
+        )) = self
+        {
+            Some(s.to_owned())
         } else {
             None
         }

--- a/crates/wasm_runtime/src/errors.rs
+++ b/crates/wasm_runtime/src/errors.rs
@@ -68,7 +68,7 @@ impl WasmRuntimeError {
     }
     pub fn reason(&self) -> Option<TrapCode> {
         if let Self::RuntimeError { reason, .. } = self {
-            return Some(reason.clone());
+            return Some(*reason);
         }
         None
     }
@@ -94,13 +94,13 @@ impl From<RuntimeError> for WasmRuntimeError {
                 reason,
                 msg: value.message(),
                 trace: value.trace().to_owned(),
-                origin: value.source().and_then(|err| Some(format!("{err:?}"))),
+                origin: value.source().map(|err| format!("{err:?}")),
             }
         } else {
             Self::RuntimeErrorLossy {
                 msg: value.message(),
                 trace: value.trace().to_owned(),
-                origin: value.source().and_then(|err| Some(format!("{err:?}"))),
+                origin: value.source().map(|err| format!("{err:?}")),
             }
         }
     }

--- a/crates/wasm_runtime/src/limiting_tunables.rs
+++ b/crates/wasm_runtime/src/limiting_tunables.rs
@@ -29,7 +29,7 @@ impl<T: Tunables> LimitingTunables<T> {
     /// valid. However, this can produce invalid types, such that
     /// validate_memory must be called before creating the memory.
     fn adjust_memory(&self, requested: &MemoryType) -> MemoryType {
-        let mut adjusted = requested.clone();
+        let mut adjusted = *requested;
         if requested.maximum.is_none() {
             adjusted.maximum = Some(self.limit);
         }

--- a/crates/wasm_runtime/src/rust2wasm/stack_overflow.rs
+++ b/crates/wasm_runtime/src/rust2wasm/stack_overflow.rs
@@ -9,6 +9,10 @@ fn main() {
     let mut stack = Vec::new();
     add_plate(&mut stack)
 }
+// This allow statement is **not** part of the code used in
+// creating the relative .wasm file and is only used here
+// to dismiss clippy warnings.
+#[allow(unconditional_recursion)]
 fn add_plate(stack: &mut Vec<Plate>) {
     stack.push(Plate::new());
     add_plate(stack)

--- a/crates/wasm_runtime/src/wasm_runtime.rs
+++ b/crates/wasm_runtime/src/wasm_runtime.rs
@@ -39,7 +39,7 @@ pub struct WasmRuntime {
     args: Vec<String>,
     env: HashMap<String, String>,
 }
-
+#[allow(clippy::result_large_err)]
 impl WasmRuntime {
     /// Creates a new WasmRuntime environment to execute the WASM binary passed
     /// in.

--- a/crates/wasm_runtime/src/wasm_runtime.rs
+++ b/crates/wasm_runtime/src/wasm_runtime.rs
@@ -153,6 +153,7 @@ impl WasmRuntime {
             get_remaining_points(store, &instance)
         );
 
-        Ok(wasi_fn_env.cleanup(store, None))
+        wasi_fn_env.cleanup(store, None);
+        Ok(())
     }
 }

--- a/examples/multichain.rs
+++ b/examples/multichain.rs
@@ -1,7 +1,6 @@
 use node::test_utils::create_test_network;
 use primitives::{Address, PublicKey};
 use std::str::FromStr;
-use telemetry::custom_subscriber::TelemetrySubscriber;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Closes #454 
Fixed clippy warnings, and formatted relevant files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the handling of whitelisted nodes in network components.
  - Simplified the import statements across various modules for clarity.
  - Enhanced the error handling methods in the Wasm runtime for better error reporting.
  - Optimized memory adjustment logic in the Wasm runtime.

- **Bug Fixes**
  - Fixed an issue with the filtering logic in the RPC server implementation.
  - Addressed a stack overflow concern in the Wasm runtime by adding a clippy allowance.

- **Chores**
  - Removed unused imports and variables across multiple modules to improve code maintainability.
  - Updated the handling of SIGHUP signals in the PrometheusFactory to return immediately.

- **Documentation**
  - No visible changes to end-users.

- **Style**
  - No visible changes to end-users.

- **Tests**
  - Adjusted test utilities to reflect changes in the node configuration and network setup.

- **Revert**
  - No reverts in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->