### PR TITLE
Change `rpc_port` type to `u16`

### DIFF
--- a/crates/service_config/src/lib.rs
+++ b/crates/service_config/src/lib.rs
@@ -35,7 +35,7 @@ pub struct ServiceConfig {
     /// The address to bind to for RPC calls
     pub rpc_address: String,
     /// The port to bind to for RPC calls
-    pub rpc_port: u32,
+    pub rpc_port: u16,
     /// A preshared key for authenticating RPC calls
     pub pre_shared_key: String,
     /// A TLS private key for RPC transport privacy


### PR DESCRIPTION
Closes #734 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the RPC port field in the service configuration for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->