### PR TITLE
Added some code for runtime stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,7 @@ microkv = "0.2.9"
 rustls = "0.21"
 rustls-pemfile = "1.0"
 hyper-rustls = { version = "0.24", features = ["acceptor"] }
+env_logger = "0.10"
 
 
 [dev-dependencies]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -10,3 +10,5 @@ primitives = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+env_logger = { workspace = true }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -3,5 +3,8 @@
 /// everywhere along with this crate
 pub mod custom_subscriber;
 mod metrics;
+mod request_stats;
+#[cfg(test)]
+mod tests;
 pub use metrics::*;
 pub use tracing::{self, *};

--- a/crates/telemetry/src/request_stats.rs
+++ b/crates/telemetry/src/request_stats.rs
@@ -1,0 +1,125 @@
+//! This is a module that tracks basic stats for servicing parts of complex requests. It's supposed
+//! to be a little more granular than just the total time taken to service a request, but not as
+//! granular as full-on execution profiling and without the special tools or overhead.
+use crate::log::info;
+use anyhow::{anyhow, Result};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Simple struct to track start/end times
+struct StopWatch {
+    /// Start time for this specific stat.
+    start_ms: Option<u128>,
+    /// End time for this specific stat.
+    stop_ms: Option<u128>,
+}
+
+impl StopWatch {
+    /// Creates a new stopwatch object for tracking start/end times
+    pub fn new() -> Result<Self> {
+        Ok(StopWatch {
+            start_ms: Some(Self::now()?),
+            stop_ms: None,
+        })
+    }
+
+    /// Private function for collecting the current timestamp
+    fn now() -> Result<u128> {
+        Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())
+    }
+
+    /// Calculate the duration from the start and stop times.
+    pub fn duration(&self) -> Result<u128> {
+        let start: u128;
+        let stop: u128;
+
+        match self.start_ms {
+            Some(val) => {
+                start = val;
+            }
+            None => return Err(anyhow!("StopWatch was never started")),
+        }
+
+        match self.stop_ms {
+            Some(val) => {
+                stop = val;
+            }
+            None => return Err(anyhow!("StopWatch wasn't stopped")),
+        }
+
+        if start > stop {
+            return Err(anyhow!("StopWatch time went backwards"));
+        }
+        let ret = stop - start;
+        Ok(ret)
+    }
+
+    /// Stop a started stopwatch
+    pub fn stop(&mut self) -> Result<()> {
+        self.stop_ms = Some(Self::now()?);
+        Ok(())
+    }
+}
+
+pub struct RequestStats {
+    /// A label to identify this whole collection of stats. This is added to the default output,
+    /// but has no special meaning. A good example might be to make this the module name.
+    pub name: String,
+    /// An instance ID for this specific set of stats. There is no special meaning to this
+    /// attribute, but it is logged and a job UUID would be an example of a good choice here.
+    pub instance: String,
+    /// We maintain the stats internally in vectors for now because we're not expecting this to be
+    /// used for a large number of stats within a given request. We also want to maintain the order
+    /// that these are passed to us by the caller. The labels attribute is a set of string labels
+    /// passed by the caller for them to identify stats in the output. It is assumed that these are
+    /// unique within a given instance of [RequestStats].
+    labels: Vec<String>,
+    /// The stats values are stored in a second vector and we try to match these with the labels
+    /// above.
+    values: Vec<StopWatch>,
+}
+
+impl RequestStats {
+    /// Creates a new [RequestStats] instance, with [name] and [instance] being strings provided by
+    /// the caller to help them identify instances in any output.
+    pub fn new(name: String, instance: String) -> Result<Self> {
+        Ok(RequestStats {
+            name,
+            instance,
+            labels: vec!["total".to_string()],
+            values: vec![StopWatch::new()?],
+        })
+    }
+
+    /// Starts measuring a new stat within this [RequestStats] instance.
+    pub fn start(&mut self, name: String) -> Result<()> {
+        self.labels.push(name);
+        self.values.push(StopWatch::new()?);
+        Ok(())
+    }
+
+    /// Stops measuring a started stat within this [RequestStats] instance. Only likely to fail in
+    /// cases where we provide a named stat where the named stat doesn't already exist. The [name]
+    /// parameter should refer to a stat created by [self.start()].
+    pub fn stop(&mut self, name: String) -> Result<()> {
+        if let Some(index) = self.labels.iter().position(|v| v == name.as_str()) {
+            self.values[index].stop()?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RequestStats {
+    /// The default destructor simply dumps a single line of text to the logging framework.
+    fn drop(&mut self) {
+        let _ = self.stop("total".to_string());
+        let mut output = String::new();
+        output += &format!("{}: {}", &self.name, &self.instance).to_string();
+        for (i, stat) in self.labels.iter().enumerate() {
+            if let Ok(val) = &self.values[i].duration() {
+                output += &format!("; {}={} ", &stat, &val.to_string());
+            }
+            //output += &format!("{}={}", &stat, &self.values[i].duration()?.to_string());
+        }
+        info!("RequestStat: {}", output);
+    }
+}

--- a/crates/telemetry/src/tests.rs
+++ b/crates/telemetry/src/tests.rs
@@ -1,0 +1,17 @@
+// Tests for request stats
+use crate::request_stats::RequestStats;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[test]
+fn req_stats_ok() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let mut stats = RequestStats::new("Test".to_string(), "req_stats_ok".to_string())
+        .expect("Failed to create new stats object");
+    stats.start("1sec".to_string()).expect("Failed to start");
+    sleep(Duration::from_secs(1));
+    stats.stop("1sec".to_string()).expect("Failed to stop");
+    stats.start("3sec".to_string()).expect("Failed to start");
+    sleep(Duration::from_secs(3));
+    stats.stop("3sec".to_string()).expect("Failed to stop");
+}


### PR DESCRIPTION
This adds a quick API for measuring the duration taken by stuff to execute. It's a start and can be improved, but I want to use this within the compute runtime for measuring (and logging) the amount of time that compute job containers take to prep/build/execute etc. It'll likely be useful for other things later too. The default is to emit a single-line log message on drop(). Here's an example:

>     [2023-12-26T02:02:44Z INFO  telemetry::request_stats] RequestStat: Test: req_stats_ok; total=4000 ; 1sec=1000 ; 3sec=3000

In this case, I've created this stats object with the module name `Test`, instance as `req_stats_ok` and I called start/stop twice -- once for a 1 second sleep and once for a 3 second sleep (with corresponding labels).