### PR TITLE
Added subcommand to WASM CLI to publish contract to IPFS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7566,12 +7566,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "telemetry",
+ "tokio",
  "wasm_loader",
  "wasm_runtime",
  "wasmer",
  "wasmer-wasix",
  "wasmer-wasix-types",
+ "web3_pkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ vrrb_vrf = { path = "crates/consensus/vrrb_vrf" }
 wallet = { path = "crates/wallet" }
 wasm_loader = { path = "crates/wasm_loader" }
 wasm_runtime = { path = "crates/wasm_runtime" }
+web3_pkg = { path = "crates/web3_pkg" }
 metric_exporter = {path = "crates/metric_exporter" }
 
 # Github crates

--- a/crates/wasm_cli/Cargo.toml
+++ b/crates/wasm_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm_cli"
-description = "VRRB developer CLI and WASM runtime"
+description = "Versatus developer CLI and WASM runtime"
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -16,8 +16,13 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 telemetry = { workspace = true }
+tokio = { workspace = true }
 wasm_loader = { workspace = true }
 wasm_runtime = { workspace = true }
 wasmer = { workspace = true }
 wasmer-wasix = { workspace = true }
 wasmer-wasix-types = { workspace = true }
+web3_pkg = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/wasm_cli/src/cli.rs
+++ b/crates/wasm_cli/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 
-use crate::commands::{describe::DescribeOpts, execute::ExecuteOpts, validate::ValidateOpts};
+use crate::commands::{
+    describe::DescribeOpts, execute::ExecuteOpts, publish::PublishOpts, validate::ValidateOpts,
+};
 
 #[derive(Parser)]
 #[clap(author, version, about)]
@@ -18,4 +20,6 @@ pub enum WasmCommands {
     Execute(ExecuteOpts),
     /// Validates a WASM module's ability to execute
     Validate(ValidateOpts),
+    /// Publishes a smart contract package to the network
+    Publish(PublishOpts),
 }

--- a/crates/wasm_cli/src/commands/mod.rs
+++ b/crates/wasm_cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod describe;
 pub mod execute;
+pub mod publish;
 pub mod validate;

--- a/crates/wasm_cli/src/commands/publish/mod.rs
+++ b/crates/wasm_cli/src/commands/publish/mod.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use clap::Parser;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path::PathBuf;
+use web3_pkg::web3_pkg::{
+    Web3ContentId, Web3ObjectType, Web3PackageArchitecture, Web3PackageBuilder, Web3PackageObject,
+    Web3PackageObjectBuilder, Web3PackageType,
+};
+use web3_pkg::web3_store::Web3Store;
+
+#[derive(Parser, Debug)]
+pub struct PublishOpts {
+    /// The path to the WASM object file to package and publish
+    #[clap(short, long, value_parser, value_name = "FILE")]
+    pub wasm: PathBuf,
+    /// The name of the package to create
+    #[clap(short, long, value_parser, value_name = "NAME")]
+    pub name: String,
+    /// The author of the package
+    #[clap(short, long, value_parser, value_name = "AUTHOR")]
+    pub author: String,
+    /// The version of the package
+    #[clap(short, long, value_parser, value_name = "VERSION")]
+    pub version: u32,
+}
+
+/// Generate a web3-native package from a smart contract and publish it to the network. This is a
+/// stripped-down implementation of what's in the web3-pkg example that's supposed to be pretty
+/// trivial for publishing a smart contract.
+pub async fn run(opts: &PublishOpts) -> Result<()> {
+    let store = Web3Store::local()?;
+    let mut objects: Vec<Web3PackageObject> = vec![];
+
+    let cid = store.write_object(std::fs::read(&opts.wasm)?).await?;
+
+    // Keep the filename portion of the path as a user-readable label
+    let path = Path::new(&opts.wasm)
+        .file_name()
+        .unwrap_or(OsStr::new("unknown"))
+        .to_str()
+        .unwrap_or_default();
+
+    let obj = Web3PackageObjectBuilder::default()
+        .object_arch(Web3PackageArchitecture::Wasm32Wasi)
+        .object_path(path.to_string().to_owned())
+        .object_cid(Web3ContentId { cid })
+        .object_type(Web3ObjectType::Executable)
+        .build()?;
+
+    objects.push(obj);
+
+    let pkg_meta = Web3PackageBuilder::default()
+        .pkg_version(opts.version)
+        .pkg_name(opts.name.to_owned())
+        .pkg_author(opts.author.to_owned())
+        .pkg_type(Web3PackageType::SmartContract)
+        .pkg_objects(objects)
+        .pkg_replaces(vec![])
+        .build()?;
+    let json = serde_json::to_string(&pkg_meta)?;
+
+    let cid = store.write_dag(json.into()).await?;
+
+    println!("Content ID for Web3 Package is {}", cid);
+
+    Ok(())
+}

--- a/crates/wasm_cli/src/main.rs
+++ b/crates/wasm_cli/src/main.rs
@@ -18,6 +18,10 @@ fn main() -> Result<()> {
         Some(cli::WasmCommands::Validate(opts)) => {
             commands::validate::run(opts)?;
         }
+        Some(cli::WasmCommands::Publish(opts)) => {
+            let rt = tokio::runtime::Runtime::new()?;
+            let _ = rt.block_on(async { commands::publish::run(opts).await })?;
+        }
         None => {}
     }
 


### PR DESCRIPTION
I've extended the WASM CLI to include a subcommand on the CLI that will allow the user to publish a smart contract via IPFS. It'll need some integration with the wallet API/CLI/RPC later to notify the protocol to pin the contract package locally, but that needs some future protocol work. Here's an example of a package that's been published. I'll have it pinned somewhere that's permanently connected.

https://explore.ipld.io/#/explore/bafyreigk5pmbml6v4ibrdfhmyjgsqzsvvmh4kvz4sa6xmn5wlun26ee7gu

@Ghlee433 , we'll probably add some documentation to the smart contract guide(s) that calls this out. I'll hit you up about that in parallel.