### PR TITLE
Feat resolve dns ipfsclient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
   "crates/wasm_loader",
   "crates/wasm_runtime",
   "crates/web3_pkg",
-  "crates/storage_agent"
+  "crates/storage_agent",
 ]
 exclude = ["benches"]
 resolver = "2"
@@ -113,7 +113,7 @@ jsonrpsee = { version = "0.16", features = [
   "server-core",
   "server",
   "http-client",
-  "ws-client"
+  "ws-client",
 ] }
 lazy_static = "1.4"
 lru_time_cache = "0.11"

--- a/crates/internal_rpc/src/api.rs
+++ b/crates/internal_rpc/src/api.rs
@@ -1,11 +1,11 @@
-use std::fmt::Debug;
-use std::str::FromStr;
 use jsonrpsee::proc_macros::rpc;
 use platform::services::ServiceStatusResponse;
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::str::FromStr;
 pub(crate) type RpcResult<T> = Result<T, jsonrpsee::core::Error>;
 
-#[derive(Serialize, Deserialize,Debug,Copy,Clone)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub enum IPFSDataType {
     Object,
     Dag,
@@ -23,8 +23,6 @@ impl FromStr for IPFSDataType {
         }
     }
 }
-
-
 
 /// The methods available to the [`InternalRpcServer`] for both
 /// the client and the server.

--- a/crates/storage_agent/src/commands/data_retrieval/mod.rs
+++ b/crates/storage_agent/src/commands/data_retrieval/mod.rs
@@ -32,11 +32,7 @@ pub async fn run(opts: &DataRetrievalOpts, config: &ServiceConfig) -> Result<()>
         error!("Path does not exist.");
         return Err(anyhow::anyhow!("Path does not exist.".to_string()));
     }
-    let blob = client
-        .0
-        .get_data(&opts.cid, opts.data_type)
-        .await?;
-    
+    let blob = client.0.get_data(&opts.cid, opts.data_type).await?;
     if !blob.is_empty() {
         for (cid, blob) in blob.iter() {
             let file_path = std::path::Path::new(&opts.blob_path).join(cid);

--- a/crates/wasm_cli/src/commands/publish/mod.rs
+++ b/crates/wasm_cli/src/commands/publish/mod.rs
@@ -10,7 +10,7 @@ use web3_pkg::web3_pkg::{
 };
 use web3_pkg::web3_store::Web3Store;
 
-pub const VERSATUS_STORAGE_ADDRESS: &'static str = "storage.versatus.net";
+pub const VERSATUS_STORAGE_ADDRESS: &str = "storage.versatus.net";
 #[derive(Parser, Debug)]
 pub struct PublishOpts {
     /// The path to the WASM object file to package and publish
@@ -32,6 +32,9 @@ pub struct PublishOpts {
 
     #[clap(short, long, value_parser, value_name = "IS_SRV_RECORD")]
     pub is_srv: bool,
+
+    #[clap(short, long, value_parser, value_name = "RECURSIVE_PUBLISH")]
+    pub recursive: bool,
 }
 
 /// Generate a web3-native package from a smart contract and publish it to the network. This is a

--- a/crates/web3_pkg/Cargo.toml
+++ b/crates/web3_pkg/Cargo.toml
@@ -16,8 +16,8 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 derive_builder = { workspace = true }
 futures = { version = "0.3", features = ["thread-pool"] }
-ipfs-api-backend-hyper = { version = "0.6" ,features = ["with-send-sync"] }
-ipfs-api = { version ="0.17" }
+ipfs-api-backend-hyper = { version = "0.6", features = ["with-send-sync"] }
+ipfs-api = { version = "0.17" }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/web3_pkg/Cargo.toml
+++ b/crates/web3_pkg/Cargo.toml
@@ -22,3 +22,4 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
+trust-dns-resolver = { version = "0.23.2", features = [] }

--- a/crates/web3_pkg/src/web3_store.rs
+++ b/crates/web3_pkg/src/web3_store.rs
@@ -10,7 +10,6 @@ use trust_dns_resolver::Resolver;
 
 /// A structure representing a content-addressable Web3 store. Currently closely tied to IPFS
 /// specifically, but could be expanded to others, such as Iroh.
-
 pub struct Web3Store {
     client: IpfsClient,
 }
@@ -72,9 +71,9 @@ impl Web3Store {
 
     /// A constructor that takes domain host name  or SRV record and resolves it to ipv4/ipv6 addresses
     /// and then use the address for RPC service on an IPFS instance
-    pub fn from_hostname(addr: &str,is_srv:bool) -> Result<Self> {
-        let addresses=Self::resolve_dns(addr,is_srv)?;
-        let address=addresses.get(0).unwrap();
+    pub fn from_hostname(addr: &str, is_srv: bool) -> Result<Self> {
+        let addresses = Self::resolve_dns(addr, is_srv)?;
+        let address = addresses.get(0).unwrap();
         Ok(Web3Store {
             client: IpfsClient::from_multiaddr_str(&address.to_string())?,
         })
@@ -117,17 +116,14 @@ impl Web3Store {
         let mut addresses = Vec::new();
         if is_srv {
             let lookup = resolver.lookup(name, RecordType::SRV)?;
-            for record in  lookup.records() {
+            for record in lookup.records() {
                 if let Some(srv_data) = record.data().and_then(|data| data.as_srv()) {
                     let target = srv_data.target();
-                    addresses=Self::resolve_ip_addresses(
-                        &resolver,
-                        target.to_string().as_str(),
-                    )?;
+                    addresses = Self::resolve_ip_addresses(&resolver, target.to_string().as_str())?;
                 }
             }
         } else {
-            addresses=Self::resolve_ip_addresses(&resolver,  name)?;
+            addresses = Self::resolve_ip_addresses(&resolver, name)?;
         }
         if addresses.is_empty() {
             return Err(anyhow::Error::msg("No addresses found"));
@@ -135,11 +131,8 @@ impl Web3Store {
         Ok(addresses)
     }
 
-    fn resolve_ip_addresses(
-        resolver: &Resolver,
-        target: &str,
-    ) -> Result<Vec<IpAddr>> {
-        let mut addresses=Vec::new();
+    fn resolve_ip_addresses(resolver: &Resolver, target: &str) -> Result<Vec<IpAddr>> {
+        let mut addresses = Vec::new();
         let ip4_address = resolver.lookup(target, RecordType::A)?;
         let ip6_address = resolver.lookup(target, RecordType::AAAA)?;
         let ip4_records = ip4_address.records();

--- a/crates/web3_pkg/src/web3_store.rs
+++ b/crates/web3_pkg/src/web3_store.rs
@@ -3,6 +3,10 @@ use futures::TryStreamExt;
 use ipfs_api::{IpfsApi, IpfsClient, TryFromUri};
 use serde_derive::{Deserialize, Serialize};
 use std::io::Cursor;
+use std::net::IpAddr;
+use trust_dns_resolver::config::*;
+use trust_dns_resolver::proto::rr::RecordType;
+use trust_dns_resolver::Resolver;
 
 /// A structure representing a content-addressable Web3 store. Currently closely tied to IPFS
 /// specifically, but could be expanded to others, such as Iroh.
@@ -64,6 +68,93 @@ impl Web3Store {
         Ok(Web3Store {
             client: IpfsClient::default(),
         })
+    }
+
+    /// A constructor that takes domain host name  or SRV record and resolves it to ipv4/ipv6 addresses
+    /// and then use the address for RPC service on an IPFS instance
+    pub fn from_hostname(addr: &str,is_srv:bool) -> Result<Self> {
+        let addresses=Self::resolve_dns(addr,is_srv)?;
+        let address=addresses.get(0).unwrap();
+        Ok(Web3Store {
+            client: IpfsClient::from_multiaddr_str(&address.to_string())?,
+        })
+    }
+
+    /// Resolves DNS records and retrieves a list of IP addresses.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - A string representing the domain or host name to resolve.
+    /// * `is_srv` - A boolean indicating whether to perform an SRV record lookup.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing a vector of `IpAddr` representing the resolved IP addresses.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the resolution fails or if no addresses are found.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use crate::web3_pkg::web3_store::Web3Store;
+    ///
+    /// let result = Web3Store::resolve_dns("example.com", false);
+    /// match result {
+    ///     Ok(addresses) => {
+    ///         for addr in addresses {
+    ///             println!("Resolved IP Address: {}", addr);
+    ///         }
+    ///     }
+    ///     Err(err) => {
+    ///         eprintln!("Error: {}", err);
+    ///     }
+    /// }
+    /// ```
+    pub fn resolve_dns(name: &str, is_srv: bool) -> Result<Vec<IpAddr>> {
+        let resolver = Resolver::new(ResolverConfig::default(), ResolverOpts::default())?;
+        let mut addresses = Vec::new();
+        if is_srv {
+            let lookup = resolver.lookup(name, RecordType::SRV)?;
+            for record in  lookup.records() {
+                if let Some(srv_data) = record.data().and_then(|data| data.as_srv()) {
+                    let target = srv_data.target();
+                    addresses=Self::resolve_ip_addresses(
+                        &resolver,
+                        target.to_string().as_str(),
+                    )?;
+                }
+            }
+        } else {
+            addresses=Self::resolve_ip_addresses(&resolver,  name)?;
+        }
+        if addresses.is_empty() {
+            return Err(anyhow::Error::msg("No addresses found"));
+        }
+        Ok(addresses)
+    }
+
+    fn resolve_ip_addresses(
+        resolver: &Resolver,
+        target: &str,
+    ) -> Result<Vec<IpAddr>> {
+        let mut addresses=Vec::new();
+        let ip4_address = resolver.lookup(target, RecordType::A)?;
+        let ip6_address = resolver.lookup(target, RecordType::AAAA)?;
+        let ip4_records = ip4_address.records();
+        for record in ip4_records {
+            if let Some(ip4_data) = record.data().and_then(|data| data.as_a()) {
+                addresses.push(IpAddr::V4(ip4_data.0));
+            }
+        }
+        let ip6_records = ip6_address.records();
+        for record in ip6_records {
+            if let Some(ip6_data) = record.data().and_then(|data| data.as_aaaa()) {
+                addresses.push(IpAddr::V6(ip6_data.0));
+            }
+        }
+        Ok(addresses)
     }
 
     /// A constructor that takes a multiaddr string (eg, "/ip4/127.0.0.1/tcp/5001") to connect to


### PR DESCRIPTION
## Summary of Changes

This pull request enhances the `Web3Store` functionality by allowing it to be built using both hostnames and IPv4/IPv6 addresses. Additionally, support for resolving hostnames has been added.

## Changes Made

- Added the ability to build `Web3Store` instances using both hostnames and IPv4/IPv6 addresses.
- Introduced code to resolve hostnames and appropriately initialize `Web3Store`.

## Context

Previously, the `Web3Store` was limited to being built only using Local host.