### PR TITLE
Added PKG info subcommand to wasm cli

### DIFF
--- a/crates/wasm_cli/src/cli.rs
+++ b/crates/wasm_cli/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+use crate::commands::pkginfo::FetchMetadataOpts;
 use crate::commands::{
     describe::DescribeOpts, execute::ExecuteOpts, publish::PublishOpts, validate::ValidateOpts,
 };
@@ -22,4 +23,6 @@ pub enum WasmCommands {
     Validate(ValidateOpts),
     /// Publishes a smart contract package to the network
     Publish(PublishOpts),
+    /// Fetching metadata about smart contract package from the network
+    PkgInfo(FetchMetadataOpts),
 }

--- a/crates/wasm_cli/src/commands/mod.rs
+++ b/crates/wasm_cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod describe;
 pub mod execute;
+pub mod pkginfo;
 pub mod publish;
 pub mod validate;

--- a/crates/wasm_cli/src/commands/pkginfo/mod.rs
+++ b/crates/wasm_cli/src/commands/pkginfo/mod.rs
@@ -1,0 +1,78 @@
+use crate::commands::publish::VERSATUS_STORAGE_ADDRESS;
+use anyhow::Result;
+use clap::Parser;
+use std::net::{IpAddr, ToSocketAddrs};
+use std::str::from_utf8;
+use web3_pkg::web3_pkg::Web3Package;
+use web3_pkg::web3_store::Web3Store;
+
+#[derive(Parser, Debug)]
+pub struct FetchMetadataOpts {
+    /// The storage server address
+    #[clap(short, long, value_parser, value_name = "STORAGE_SERVER")]
+    pub storage_server: Option<String>,
+
+    /// The path to the WASM object file to load and describe
+    #[clap(short, long, value_parser, value_name = "CID")]
+    pub cid: String,
+
+    #[clap(short, long, value_parser, value_name = "IS_SRV_RECORD")]
+    pub is_srv: bool,
+
+    /// Flag that indicates whether storage server is running locally
+    #[clap(short, long, value_parser, value_name = "LOCAL")]
+    pub is_local: bool,
+}
+
+/// Fetch metadata of web3 package from the network.
+pub fn run(opts: &FetchMetadataOpts) -> Result<()> {
+    let store = if let Some(address) = opts.storage_server.as_ref() {
+        if let Ok(ip) = address.parse::<IpAddr>() {
+            Web3Store::from_multiaddr(ip.to_string().as_str())?;
+        } else if address.to_socket_addrs().is_ok() {
+            Web3Store::from_hostname(address, opts.is_srv)?;
+        } else {
+            return Err(anyhow::Error::msg(
+                "Address is neither hostname nor IP address",
+            ));
+        }
+        Web3Store::local()?
+    } else if opts.is_local {
+        Web3Store::local()?
+    } else {
+        Web3Store::from_hostname(VERSATUS_STORAGE_ADDRESS, opts.is_srv)?
+    };
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let obj_result = store.read_dag(opts.cid.as_str()).await;
+        let obj = match obj_result {
+            Ok(obj) => obj,
+            Err(err) => {
+                eprintln!("Error reading DAG: {}", err);
+                return;
+            }
+        };
+
+        let json_result = from_utf8(&obj);
+        let json = match json_result {
+            Ok(json) => json,
+            Err(err) => {
+                eprintln!("Error converting dag metadata to UTF-8: {}", err);
+                return;
+            }
+        };
+
+        let pkg_result: Result<Web3Package, _> = serde_json::from_str(json);
+        let pkg = match pkg_result {
+            Ok(pkg) => pkg,
+            Err(err) => {
+                eprintln!("Error deserializing JSON: {}", err);
+                return;
+            }
+        };
+        println!("{}", pkg);
+    });
+
+    Ok(())
+}

--- a/crates/wasm_cli/src/main.rs
+++ b/crates/wasm_cli/src/main.rs
@@ -22,6 +22,9 @@ fn main() -> Result<()> {
             let rt = tokio::runtime::Runtime::new()?;
             rt.block_on(async { commands::publish::run(opts).await })?;
         }
+        Some(cli::WasmCommands::PkgInfo(opts)) => {
+            commands::pkginfo::run(opts)?;
+        }
         None => {}
     }
 

--- a/crates/web3_pkg/src/web3_pkg.rs
+++ b/crates/web3_pkg/src/web3_pkg.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+use std::fmt::Display;
 use clap::clap_derive::ArgEnum;
 use derive_builder::Builder;
 use serde_derive::{Deserialize, Serialize};
@@ -102,4 +104,52 @@ pub struct Web3Package {
     /// A vector of packages that this replaces. XXX: This could be problematic when exporting a
     /// DAG when there's a long history.
     pub pkg_replaces: Vec<Web3ContentId>,
+}
+
+impl Display for Web3Package {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Name: {}       Author: {}", self.pkg_name, self.pkg_author)?;
+        writeln!(f, "Type: {:?}                 Package Version: {}", self.pkg_type, self.pkg_version)?;
+        writeln!(f, "Objects:")?;
+        for obj in &self.pkg_objects {
+            writeln!(f, "     {}", obj.object_cid)?;
+            writeln!(f, "     Architecture: {}", obj.object_arch)?;
+            writeln!(f, "     Type: {:?}", obj.object_type)?;
+            writeln!(f, "     Name: {}", obj.object_path)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for Web3ContentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Cid: {} ", self.cid)?;
+        Ok(())
+    }
+}
+
+impl Display for Web3PackageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let display_name = match self {
+            Web3PackageType::None => "None",
+            Web3PackageType::SmartContractRuntime => "Smart Contract Runtime",
+            Web3PackageType::SmartContract => "Smart Contract",
+        };
+        write!(f, "{}", display_name)
+    }
+}
+
+impl Display for Web3PackageArchitecture {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let display_name = match self {
+            Web3PackageArchitecture::None => "None",
+            Web3PackageArchitecture::Amd64Linux => "x64_64-unknown-linux-gnu",
+            Web3PackageArchitecture::Amd64Musl => "x64_64-unknown-linux-musl",
+            Web3PackageArchitecture::Aarch64Linux => "aarch64-unknown-linux-gnu",
+            Web3PackageArchitecture::Aarch64Musl => "aarch64-unknown-linux-musl",
+            Web3PackageArchitecture::Wasm32Wasi => "wasm32-wasi",
+        };
+        write!(f, "{}", display_name)
+    }
 }


### PR DESCRIPTION
This pull request introduces several enhancements and additions to the `wasm` CLI tool. The major changes include:

1. **Added `pkg info` Subcommand:**
   - The PR introduces a new subcommand `pkg info` to the `wasm` CLI tool.
   - This subcommand provides detailed information about the package.

2. **Command Modifications for Storage Server:**
   - Modified existing commands related to the storage server.
   - When `--is-local` is provided, the client can now connect to a server running locally.

### Sample Input 
`/versa-wasm pkg-info --cid bafyreibm74yylrtyre2tqnhhabz5vixzogjyoff4ed5xbw2vouiqn4yu6e --is-local`

### Output 
```bash
Name: Compute Unit ERC20 Token       Author: Versatus Labs
Type: SmartContract                 Package Version: 1
Objects:
     Cid: QmXtP5iJfwByTTYuzdj7uThCKL2Zyh4Yi8bi6b7ee1j1p4 
     Architecture: wasm32-wasi
     Type: Executable
     Name: erc20.wasm
