### PR TITLE
Increased default memory maximum for WASM

### DIFF
--- a/crates/wasm_runtime/src/limiting_tunables.rs
+++ b/crates/wasm_runtime/src/limiting_tunables.rs
@@ -4,7 +4,10 @@ use wasmer::{
     MemoryError, MemoryType, Pages, TableType, Tunables,
 };
 
-pub(crate) const DEFAULT_PAGE_LIMIT: Pages = Pages(24);
+// Default max is 48 * 64Kb pages, or 3MB. This ought to be enough for most
+// smart contract use cases, but will likley need to be adjusted for other
+// WASM use cases in the future.
+pub(crate) const DEFAULT_PAGE_LIMIT: Pages = Pages(48);
 
 /// A custom tunables that allows you to set a memory limit.
 ///


### PR DESCRIPTION
@hathbanger 's latest JS contract starts at 30 pages, whereas other contracts (such as the old Rust ERC20 contract) start at 17 pages. The default of 24 pages prevents the JS contract from running. This change ups the limit to 48 page, or 3MB. We'll probably make this tunable later depending on the type of WASM workload being run, but this ought to hopefully get us going for beta.