### PR TITLE
Only report contract errors if `stderr` is non-empty

### DIFF
--- a/crates/wasm_cli/src/commands/execute/mod.rs
+++ b/crates/wasm_cli/src/commands/execute/mod.rs
@@ -79,7 +79,9 @@ pub fn run(opts: &ExecuteOpts) -> Result<()> {
     // Temporary output for user -- will eventually be more structured and both
     // human and machine readable.
     println!("{}", &wasm.stdout());
-    eprintln!("Contract errors: {}", &wasm.stderr());
+    if !&wasm.stderr().is_empty() {
+        eprintln!("Contract errors: {}", &wasm.stderr());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Adds a conditional expression that checks if `stderr` is non-empty before printing.