### PR TITLE
 Update is_pinned Function Signature and Address Clippy Suggestions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ jsonrpsee = { version = "0.16", features = [
   "server-core",
   "server",
   "http-client",
-  "ws-client"
+  "ws-client",
 ] }
 lazy_static = "1.4"
 log = "0.4"

--- a/crates/internal_rpc/src/api.rs
+++ b/crates/internal_rpc/src/api.rs
@@ -56,6 +56,6 @@ pub trait InternalRpcApi {
     #[method(name = "pin_object")]
     async fn pin_object(&self, cid: &str, recursive: bool) -> RpcResult<Vec<String>>;
 
-    #[method(name = "is_pinned")]
-    async fn is_pinned(&self, cid: &str) -> RpcResult<()>;
+    #[method(name = "pinned_status")]
+    async fn pinned_status(&self, cid: &str) -> RpcResult<()>;
 }

--- a/crates/internal_rpc/src/api.rs
+++ b/crates/internal_rpc/src/api.rs
@@ -57,5 +57,5 @@ pub trait InternalRpcApi {
     async fn pin_object(&self, cid: &str, recursive: bool) -> RpcResult<Vec<String>>;
 
     #[method(name = "is_pinned")]
-    async fn is_pinned(&self, cid: &str) -> RpcResult<bool>;
+    async fn is_pinned(&self, cid: &str) -> RpcResult<()>;
 }

--- a/crates/internal_rpc/src/server.rs
+++ b/crates/internal_rpc/src/server.rs
@@ -155,7 +155,7 @@ impl<T: ServiceTransmitter<J> + 'static, J: ServiceJobApi + Debug + 'static> Int
     async fn pin_object(&self, cid: &str, recursive: bool) -> RpcResult<Vec<String>> {
         self.pin_object_ipfs(cid, recursive).await
     }
-    async fn is_pinned(&self, cid: &str) -> RpcResult<()> {
+    async fn pinned_status(&self, cid: &str) -> RpcResult<()> {
         self.is_pinned_obj(cid).await
     }
 }

--- a/crates/internal_rpc/src/server.rs
+++ b/crates/internal_rpc/src/server.rs
@@ -114,14 +114,13 @@ impl<T: ServiceTransmitter<J>, J: ServiceJobApi + Debug> InternalRpc<T, J> {
         Ok(obj)
     }
 
-    async fn is_pinned_obj(&self, cid: &str) -> RpcResult<bool> {
+    async fn is_pinned_obj(&self, cid: &str) -> RpcResult<()> {
         info!(
             "Checking whether object '{}' is pinned to local IPFS instance.",
             &cid
         );
         let store = Web3Store::local()?;
-        let is_pinned = store.is_pinned(cid).await?;
-        Ok(is_pinned)
+        store.is_pinned(cid).await.map_err(|err| err.into())
     }
 }
 
@@ -156,7 +155,7 @@ impl<T: ServiceTransmitter<J> + 'static, J: ServiceJobApi + Debug + 'static> Int
     async fn pin_object(&self, cid: &str, recursive: bool) -> RpcResult<Vec<String>> {
         self.pin_object_ipfs(cid, recursive).await
     }
-    async fn is_pinned(&self, cid: &str) -> RpcResult<bool> {
+    async fn is_pinned(&self, cid: &str) -> RpcResult<()> {
         self.is_pinned_obj(cid).await
     }
 }

--- a/crates/storage_agent/src/commands/pin_status/mod.rs
+++ b/crates/storage_agent/src/commands/pin_status/mod.rs
@@ -14,22 +14,20 @@ pub async fn run(opts: &PinStatusOpts, config: &ServiceConfig) -> Result<()> {
     // XXX: This where we would make the pin object  RPC call to the named service (global option) from
     // the service config file (global option) and show the result.
     let client = InternalRpcClient::new(config.rpc_socket_addr()?).await?;
-    let pin_status: Result<bool> = client
+    let pin_status: Result<()> = client
         .0
         .is_pinned(&opts.cid)
         .await
         .map_err(|err| err.into());
-    if let Ok(pin_status) = pin_status {
         match pin_status {
-            true => println!(
+            Ok(()) => println!(
                 "The content associated with CID '{}' is pinned in IPFS.",
                 &opts.cid
             ),
-            false => println!(
-                "The content associated with CID '{}' is not pinned in IPFS.",
-                &opts.cid
+            Err(e) => println!(
+                "The content associated with CID '{}' is not pinned in IPFS. Details {}",
+                &opts.cid,e
             ),
         }
-    }
     Ok(())
 }

--- a/crates/storage_agent/src/commands/pin_status/mod.rs
+++ b/crates/storage_agent/src/commands/pin_status/mod.rs
@@ -16,7 +16,7 @@ pub async fn run(opts: &PinStatusOpts, config: &ServiceConfig) -> Result<()> {
     let client = InternalRpcClient::new(config.rpc_socket_addr()?).await?;
     let pin_status: Result<()> = client
         .0
-        .is_pinned(&opts.cid)
+        .pinned_status(&opts.cid)
         .await
         .map_err(|err| err.into());
         match pin_status {

--- a/crates/wasm_cli/src/commands/pkginfo/mod.rs
+++ b/crates/wasm_cli/src/commands/pkginfo/mod.rs
@@ -31,12 +31,10 @@ pub struct FetchMetadataOpts {
 
 impl FetchMetadataOpts {
     pub fn validate(&self) -> Result<()> {
-        if self.storage_server.is_some() {
-            if self.is_srv.is_none() {
-                return Err(anyhow::anyhow!(
-                    "If storage-server is provided, is_srv must also be provided."
-                ));
-            }
+        if self.storage_server.is_some() && self.is_srv.is_none() {
+            return Err(anyhow::anyhow!(
+                "If storage-server is provided, is_srv must also be provided."
+            ));
         }
         Ok(())
     }

--- a/crates/wasm_cli/src/commands/pkginfo/mod.rs
+++ b/crates/wasm_cli/src/commands/pkginfo/mod.rs
@@ -57,7 +57,7 @@ pub fn run(opts: &FetchMetadataOpts) -> Result<()> {
     } else if opts.is_local {
         Web3Store::local()?
     } else {
-        Web3Store::from_hostname(VERSATUS_STORAGE_ADDRESS, is_srv)?
+        Web3Store::from_hostname(VERSATUS_STORAGE_ADDRESS, true)?
     };
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {

--- a/crates/wasm_cli/src/commands/publish/mod.rs
+++ b/crates/wasm_cli/src/commands/publish/mod.rs
@@ -71,7 +71,7 @@ pub fn run(opts: &PublishOpts) -> Result<()> {
     } else if opts.is_local {
         Web3Store::local()?
     } else {
-        Web3Store::from_hostname(VERSATUS_STORAGE_ADDRESS, is_srv)?
+        Web3Store::from_hostname(VERSATUS_STORAGE_ADDRESS, true)?
     };
 
     // Define some package and object annotations to include.

--- a/crates/wasm_cli/src/commands/publish/mod.rs
+++ b/crates/wasm_cli/src/commands/publish/mod.rs
@@ -42,12 +42,10 @@ pub struct PublishOpts {
 
 impl PublishOpts {
     pub fn validate(&self) -> Result<()> {
-        if self.storage_server.is_some() {
-            if self.is_srv.is_none() {
-                return Err(anyhow::anyhow!(
-                    "If storage-server is provided, is_srv must also be provided."
-                ));
-            }
+        if self.storage_server.is_some() && self.is_srv.is_none() {
+            return Err(anyhow::anyhow!(
+                "If storage-server is provided, is_srv must also be provided."
+            ));
         }
         Ok(())
     }

--- a/crates/web3_pkg/src/web3_store.rs
+++ b/crates/web3_pkg/src/web3_store.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use futures::TryStreamExt;
 use http::uri::Scheme;
 use ipfs_api::{IpfsApi, IpfsClient, TryFromUri};
@@ -228,11 +228,14 @@ impl Web3Store {
     }
 
     /// Checks if object is pinned
-    pub async fn is_pinned(&self, cid: &str) -> Result<bool> {
+    pub async fn is_pinned(&self, cid: &str) -> Result<()> {
         let res = self.client.pin_ls(Some(cid), None).await?;
-        Ok(!res.keys.is_empty())
-    }
 
+        if res.keys.is_empty() {
+            return Err(anyhow!("The CID {} is not pinned.", cid));
+        }
+        Ok(())
+    }
     /// A method to retrieve stats from the IPFS service and return them
     pub async fn stats(&self) -> Result<Web3StoreStats> {
         let repo = self.client.stats_repo().await?;

--- a/crates/web3_pkg/src/web3_store.rs
+++ b/crates/web3_pkg/src/web3_store.rs
@@ -3,6 +3,7 @@ use futures::TryStreamExt;
 use http::uri::Scheme;
 use ipfs_api::{IpfsApi, IpfsClient, TryFromUri};
 use serde_derive::{Deserialize, Serialize};
+use std::fmt::Debug;
 use std::io::Cursor;
 use std::net::{IpAddr, SocketAddr};
 use trust_dns_resolver::proto::rr::RecordType;
@@ -73,7 +74,7 @@ impl Web3Store {
     /// and then use the address for RPC service on an IPFS instance
     pub fn from_hostname(addr: &str, is_srv: bool) -> Result<Self> {
         let addresses = Self::resolve_dns(addr, is_srv)?;
-        let address = addresses.get(0).unwrap();
+        let address = addresses.first().unwrap();
         let ip = address.ip();
         let port = address.port();
         Ok(Web3Store {


### PR DESCRIPTION
Bug Fix: Default `is-srv` flag to true; earlier, it was considering storage address as AAAA record.
Fixed `clippy` changes.
Refactor: Change return type of `is_pinned` function.
Refactor: Rename `is_pinned` to `pinned_status`.
The `is_pinned` function signature has been updated to better reflect its behavior. Instead of returning a boolean indicating whether the CID is pinned, it now returns a `RpcResult<()>`.

   Before:
   ```rust
   async fn is_pinned(&self, cid: &str) -> RpcResult<bool>;
   ```

   After:
   ```rust
   async fn pinned_status(&self, cid: &str) -> RpcResult<()>;
   ```