### PR TITLE
Add dbg print of `wasm_runtime` module

### DIFF
--- a/crates/wasm_runtime/src/wasm_runtime.rs
+++ b/crates/wasm_runtime/src/wasm_runtime.rs
@@ -69,6 +69,7 @@ impl WasmRuntime {
         // Compile module into in-memory store
         let module = Module::new(&store, wasm_bytes)
             .map_err(|e| WasmRuntimeError::ModuleBuildError(format!("{e:?}")))?;
+        dbg!(&module);
         Ok(Self {
             store,
             module,


### PR DESCRIPTION
Debug the wasm runtime module once it's created, ensuring we can see that the store created from the engine is successfully being validated.