### PR TITLE
Set mem limit to 64 and added checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7834,10 +7834,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "derive_builder 0.12.0",
- "telemetry",
+ "log",
  "test-log",
  "wasmer",
- "wasmparser 0.107.0",
+ "wasmparser 0.121.1",
 ]
 
 [[package]]
@@ -8103,11 +8103,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.107.0"
+version = "0.121.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
+checksum = "99ffe16b4aa1ebab8724f61c9ee38cd5481c89caf10bf1a5af9eab8f0c2e6c05"
 dependencies = [
- "indexmap 1.9.3",
+ "bitflags 2.4.1",
+ "indexmap 2.1.0",
  "semver 1.0.21",
 ]
 

--- a/crates/wasm_cli/src/commands/describe/mod.rs
+++ b/crates/wasm_cli/src/commands/describe/mod.rs
@@ -23,12 +23,14 @@ pub fn run(opts: &DescribeOpts) -> Result<()> {
     println!("Running describe for {}", filename);
     let wasm_loader = WasmLoaderBuilder::from_filename(filename)?;
 
-    println!("WASM?  {}", wasm_loader.from_wat);
-    println!("WASI?  {}", wasm_loader.is_wasi);
-    println!("WASIX? {}", wasm_loader.is_wasix);
-    println!("Javy?  {}", wasm_loader.needs_javy);
-    println!("Start? {}", wasm_loader.has_start);
-    println!("VRRB?  {}", wasm_loader.has_vrrb);
+    println!("WASM?      {}", wasm_loader.from_wat);
+    println!("Version    {}", wasm_loader.wasm_version);
+    println!("Memory     {} pages", wasm_loader.wasm_memory);
+    println!("WASI?      {}", wasm_loader.is_wasi);
+    println!("WASIX?     {}", wasm_loader.is_wasix);
+    println!("Javy?      {}", wasm_loader.needs_javy);
+    println!("Start?     {}", wasm_loader.has_start);
+    println!("Versatus?  {}", wasm_loader.has_versatus);
     println!("Namespaces: {:?}", wasm_loader.imports.keys());
 
     Ok(())

--- a/crates/wasm_cli/src/commands/pkginfo/mod.rs
+++ b/crates/wasm_cli/src/commands/pkginfo/mod.rs
@@ -2,7 +2,7 @@ use crate::commands::publish::VERSATUS_STORAGE_ADDRESS;
 use anyhow::Result;
 use clap::Parser;
 use multiaddr::Multiaddr;
-use std::net::{SocketAddr, AddrParseError};
+use std::net::{AddrParseError, SocketAddr};
 use std::str::from_utf8;
 use web3_pkg::web3_pkg::Web3Package;
 use web3_pkg::web3_store::Web3Store;
@@ -57,14 +57,14 @@ pub fn run(opts: &FetchMetadataOpts) -> Result<()> {
         Web3Store::local()?
     } else {
         if let Ok(addr) = std::env::var("VIPFS_ADDRESS") {
-            let socket_addr: Result<SocketAddr, AddrParseError>  = addr.parse();
+            let socket_addr: Result<SocketAddr, AddrParseError> = addr.parse();
             if let Ok(qualified_addr) = socket_addr {
                 let (ip_protocol, ip) = match qualified_addr.ip() {
                     std::net::IpAddr::V4(ip) => ("ip4".to_string(), ip.to_string()),
                     std::net::IpAddr::V6(ip) => ("ip6".to_string(), ip.to_string()),
                 };
                 let port = qualified_addr.port().to_string();
-                
+
                 let multiaddr_string = format!("/{ip_protocol}/{ip}/tcp/{port}");
 
                 Web3Store::from_multiaddr(&multiaddr_string)?

--- a/crates/wasm_cli/src/commands/publish/mod.rs
+++ b/crates/wasm_cli/src/commands/publish/mod.rs
@@ -72,14 +72,14 @@ pub fn run(opts: &PublishOpts) -> Result<()> {
         Web3Store::local()?
     } else {
         if let Ok(addr) = std::env::var("VIPFS_ADDRESS") {
-            let socket_addr: Result<SocketAddr, AddrParseError>  = addr.parse();
+            let socket_addr: Result<SocketAddr, AddrParseError> = addr.parse();
             if let Ok(qualified_addr) = socket_addr {
                 let (ip_protocol, ip) = match qualified_addr.ip() {
                     std::net::IpAddr::V4(ip) => ("ip4".to_string(), ip.to_string()),
                     std::net::IpAddr::V6(ip) => ("ip6".to_string(), ip.to_string()),
                 };
                 let port = qualified_addr.port().to_string();
-                
+
                 let multiaddr_string = format!("/{ip_protocol}/{ip}/tcp/{port}");
 
                 Web3Store::from_multiaddr(&multiaddr_string)?

--- a/crates/wasm_cli/src/commands/validate/mod.rs
+++ b/crates/wasm_cli/src/commands/validate/mod.rs
@@ -22,7 +22,7 @@ const SUPPORTED_NAMESPACES: &[&str] = &[ENV, WASI_SNAPSHOT_PREVIEW1];
 pub fn run(opts: &ValidateOpts) -> Result<()> {
     let mut expected_to_run = true;
     let filename = opts.wasm.to_str().expect("Need path name");
-    println!("Running describe for {}", filename);
+    println!("Running validation for {}", filename);
     let w = WasmLoaderBuilder::default()
         .wasm_bytes(
             std::fs::read(filename)

--- a/crates/wasm_cli/src/commands/validate/mod.rs
+++ b/crates/wasm_cli/src/commands/validate/mod.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
 use wasm_loader::wasm_loader::WasmLoaderBuilder;
+use wasm_runtime::limiting_tunables::DEFAULT_PAGE_LIMIT;
 
 #[derive(Parser, Debug)]
 pub struct ValidateOpts {
@@ -31,6 +32,20 @@ pub fn run(opts: &ValidateOpts) -> Result<()> {
         .map_err(|e| anyhow::Error::msg(format!("Error parsing Wasm file: {}", e)))?
         .build()?;
 
+    if w.wasm_version != 1 {
+        println!("WASM Version {} not yet supported.", w.wasm_version);
+        expected_to_run = false;
+    }
+
+    let limit: u64 = DEFAULT_PAGE_LIMIT.0.into();
+    if w.wasm_memory > limit {
+        println!(
+            "WASM module needs {} pages of memory. Current limit for contracts is {}.",
+            w.wasm_memory, limit
+        );
+        expected_to_run = false;
+    }
+
     if !w.is_wasi && !w.is_wasix {
         println!("WASM module isn't built for use with WASI/WASIX");
         expected_to_run = false;
@@ -41,9 +56,14 @@ pub fn run(opts: &ValidateOpts) -> Result<()> {
         expected_to_run = false;
     }
 
-    if !w.has_vrrb {
+    if !w.has_versatus {
         // This, unlike the other checks, is not fatal
-        println!("WASM module doesn't make use of any VRRB extensions (not fatal)");
+        println!("WASM module doesn't make use of any Versatus extensions (not fatal)");
+    }
+
+    if w.needs_javy {
+        println!("WASM module is dynamically linked against Javy runtime. Should be static");
+        expected_to_run = false;
     }
 
     let mut extra_namespaces = vec![];
@@ -61,9 +81,9 @@ pub fn run(opts: &ValidateOpts) -> Result<()> {
     }
 
     if expected_to_run {
-        println!("WASM module is expected to run under the VRRB runtime");
+        println!("WASM module is expected to run under the Versatus runtime");
     } else {
-        println!("WASM module is not expected to run under the VRRB runtime");
+        println!("WASM module is not expected to run under the Versatus runtime");
     }
 
     Ok(())

--- a/crates/wasm_loader/Cargo.toml
+++ b/crates/wasm_loader/Cargo.toml
@@ -10,9 +10,9 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 derive_builder = { workspace = true }
-telemetry = { workspace = true }
+log = { workspace = true }
 wasmer = { workspace = true }
-wasmparser = "0.107"
+wasmparser = "0.121"
 
 [dev-dependencies]
 test-log = "0.2"

--- a/crates/wasm_loader/src/constants.rs
+++ b/crates/wasm_loader/src/constants.rs
@@ -17,7 +17,7 @@ pub const WASM_MAGIC: &[u8; 4] = &[0x00, 0x61, 0x73, 0x6d];
 pub const WASM_PARSE_OFFSET: u64 = 0;
 /// Default entry point for WASM modules (think main()).
 pub const WASI_ENTRY_POINT: &str = "_start";
-/// A VRRB-specific magic string potentially exported by modules
-pub const VRRB_WASM_MAGIC: &str = "_vrrb_abi_magic";
-/// A VRRB-specific version number potentially exported by modules
-pub const VRRB_WASM_VERSION: &str = "_vrrb_abi_version";
+/// A versatus-specific magic string potentially exported by modules
+pub const VERSATUS_WASM_MAGIC: &str = "_versatus_abi_magic";
+/// A versatus-specific version number potentially exported by modules
+pub const VERSATUS_WASM_VERSION: &str = "_versatus_abi_version";

--- a/crates/wasm_loader/src/lib.rs
+++ b/crates/wasm_loader/src/lib.rs
@@ -3,7 +3,7 @@ pub mod wasm_loader;
 
 #[cfg(test)]
 mod loader_tests {
-    use telemetry::log::debug;
+    use log::debug;
     use test_log::test;
 
     use crate::wasm_loader::WasmLoaderBuilder;

--- a/crates/wasm_runtime/src/limiting_tunables.rs
+++ b/crates/wasm_runtime/src/limiting_tunables.rs
@@ -4,8 +4,8 @@ use wasmer::{
     MemoryError, MemoryType, Pages, TableType, Tunables,
 };
 
-/// Each page is 64KB. The default is 1GB.
-pub(crate) const DEFAULT_PAGE_LIMIT: Pages = Pages(15_625);
+/// Each page is 64KB. The default is 4MB
+pub const DEFAULT_PAGE_LIMIT: Pages = Pages(64);
 
 /// A custom tunables that allows you to set a memory limit.
 ///

--- a/crates/wasm_runtime/src/runtime_tests.rs
+++ b/crates/wasm_runtime/src/runtime_tests.rs
@@ -29,7 +29,7 @@ const TEST_VERSION: i32 = 5432;
 const TEST_TX_ID: &str = "81b067ac-8693-483a-8354-d7de15ab6f2c";
 const TEST_LAST_BLOCK_TIME: i64 = 1689897402;
 const TEST_RETURN_FAIL: &str = "RETURN_FAIL";
-const VRRB_CONTRACT_NAME: &str = "vrrb-contract"; //argv[0] for smart contracts
+const VRRB_CONTRACT_NAME: &str = "versatus"; //argv[0] for smart contracts
 const TEST_SPENDING_LIMIT: u64 = 10000000;
 
 fn create_test_wasm_runtime(

--- a/crates/wasm_runtime/src/wasm_runtime.rs
+++ b/crates/wasm_runtime/src/wasm_runtime.rs
@@ -1,6 +1,6 @@
 //! Web Assembly runtime execution
 //!
-//! This is the WASM runtime for the VRRB compute stack. It allows WASI/WASIX
+//! This is the WASM runtime for the Verstatus compute stack. It allows WASI/WASIX
 //! function calls and assumes that the WASM payload has a _start entry point,
 //! reads from STDIN and writes to STDOUT. It wraps around the Wasmer WASM
 //! runtime.
@@ -25,7 +25,7 @@ use wasmer_wasix::{Pipe, WasiEnv};
 
 /// This is the first command line argument, traditionally reserved for the
 /// program name (argv[0] in C and others).
-const MODULE_ARGV0: &str = "vrrb-contract";
+const MODULE_ARGV0: &str = "versatus";
 
 use crate::errors::WasmRuntimeError;
 pub type RuntimeResult<T> = Result<T, WasmRuntimeError>;


### PR DESCRIPTION
@eureka-cpu , I don't know that the published runtime package is using the version of the runtime that contains the earlier increase in the memory limit, and the code that Hath was trying to run was over that limit. In this pull request, I'm dropping the memory limit back almost as far (64 instead of 48) til we can show that it wasn't actually able to start due to the memory limit. 

For the next package (and packages after that), I'll annotate the package to also include the git hash, so that it's easy for us all to track what code we're running. (I'll also  formalise the publishing after betanet goes out so that it's not just me that's able to do it).

@hathbanger , I've also added memory (and version) stuff to the `describe` and `validate` commands for `versatus-wasm`, along with some version stuff and some tweaks to some Javascript-specific checks I'm doing. We'll keep making these checks more sophisticated, but for now `versatus-wasm validate --wasm build.wasm` will check to see if your WASM module is requesting more memory than the default limit. Also, `versatus describe --wasm build.wasm` will show you how much memory your module is built to request. Both of these give developers additional things that they can check before they even publish their contract to the network. I'll do a build of the binary runtime and the whole runtime package once this makes it into main. @Ghlee433 , we can probably also add some content to the docs for some of this too once we have it in main.

Here's an example of the output of both commands using Hath's WASM module that he was having trouble running:

```
matthew@prickle:~/src/versatus/beta-compute$ target/debug/versatus-wasm validate --wasm ~/Downloads/build.wasm
Running describe for /home/matthew/Downloads/build.wasm
WASM module doesn't make use of any Versatus extensions (not fatal)
WASM module is expected to run under the Versatus runtime
```

and

```
matthew@prickle:~/src/versatus/beta-compute$ target/debug/versatus-wasm describe --wasm ~/Downloads/build.wasm
Running describe for /home/matthew/Downloads/build.wasm
WASM?      false
Version    1
Memory     34 pages
WASI?      true
WASIX?     false
Javy?      false
Start?     true
Versatus?  false
Namespaces: ["wasi_snapshot_preview1"]
```

These will be useful for developers, and we might add these to the triage process (@Ghlee433 ). I'll make the output prettier later. :) 