### PR TITLE
Set betanet version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://versatus.io"
 repository = "https://github.com/versatus/versatus"
 edition = "2021"
 license = "MIT"
-version = "0.1.0"
+version = "0.9.0"
 
 [workspace]
 members = [


### PR DESCRIPTION
Setting Cargo.toml version for betanet. Will add a tag on main to match.