### PR TITLE
Remove unused events from `events` crate

### DIFF
--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,19 +1,13 @@
 use block::GenesisReceiver;
-use block::{
-    header::BlockHeader, Block, BlockHash, Certificate, ConvergenceBlock, ProposalBlock, RefHash,
-};
+use block::{header::BlockHeader, Block, BlockHash, Certificate, ConvergenceBlock, ProposalBlock};
 use ethereum_types::U256;
 use hbbft::sync_key_gen::Ack;
 use hbbft::{crypto::PublicKeySet, sync_key_gen::Part};
 use primitives::{
-    Address, ConvergencePartialSig, Epoch, FarmerQuorumThreshold, NodeId, NodeIdx,
-    ProgramExecutionOutput, PublicKeyShareVec, Round, Seed, Signature, TxnValidationStatus,
-    ValidatorPublicKeyShare, RUNTIME_TOPIC_STR,
+    Address, ConvergencePartialSig, FarmerQuorumThreshold, NodeId, Signature, RUNTIME_TOPIC_STR,
 };
 
 use serde::{Deserialize, Serialize};
-use signer::engine::{QuorumData, QuorumMembers};
-use std::net::SocketAddr;
 use vrrb_core::claim::Claim;
 use vrrb_core::transactions::{TransactionDigest, TransactionKind};
 
@@ -75,10 +69,6 @@ pub enum Event {
     /// `ClaimReceived(Claim)` represents a claim emitted by another node
     ClaimReceived(Claim),
 
-    /// `ClaimAbandoned(String,Vec<u8>)` represents a claim that turned out to
-    /// be invalid.
-    ClaimAbandoned(NodeId, Claim),
-
     /// A peer joined the network, should be added to the node's peer list
     PeerJoined(PeerData),
 
@@ -93,12 +83,6 @@ pub enum Event {
     /// request for Account updation on the chain has been requested.
     AccountUpdateRequested((Address, AccountBytes)),
 
-    /// `PeerSyncFailed(Vec<SocketAddr>)` is an event that is triggered when a
-    /// peer address synchronization attempt fails. The `Vec<SocketAddr>`
-    /// parameter contains a list of socket addresses of the peers
-    /// that failed to synchronize their address.
-    PeerSyncFailed(Vec<SocketAddr>),
-
     /// `BlockCreated(Block)` is an event that occurs whenever a block of any
     /// kind is created
     BlockCreated(Block),
@@ -110,9 +94,6 @@ pub enum Event {
     /// Event emitted by a bootrstrap QuorumModule to signal a group of nodes were assigned
     /// to a particular quorum
     QuorumMembershipAssigmentsCreated(Vec<AssignedQuorumMembership>),
-
-    /// Signals thaa a node acknowledges belonging to a quorum
-    QuorumMembershipSet(NodeId),
 
     PartCommitmentCreated(NodeId, Part),
 
@@ -131,28 +112,6 @@ pub enum Event {
     /// the network.
     HarvesterPublicKeyReceived(PublicKeySet),
 
-    /// This events triggers the generation of a certificate for a given transaction
-    TransactionCertificateRequested {
-        votes: Vec<Vote>,
-        txn_id: TransactionDigest,
-        quorum_key: PublicKeyShareVec,
-        farmer_id: NodeId,
-        txn: TransactionKind,
-        quorum_threshold: FarmerQuorumThreshold,
-    },
-
-    /// This event is emitted whenever a transaction is certified by a Farmer Quorum
-    TransactionCertificateCreated {
-        votes: Vec<Vote>,
-        signature: Signature,
-        digest: TransactionDigest,
-        /// OUtput of the program executed
-        execution_result: ProgramExecutionOutput,
-        farmer_id: NodeId,
-        txn: Box<TransactionKind>,
-        is_valid: TxnValidationStatus,
-    },
-
     MinerElectionStarted(BlockHeader),
 
     MinerElected((U256, Claim)),
@@ -161,50 +120,13 @@ pub enum Event {
         genesis_receivers: Vec<GenesisReceiver>,
     },
 
-    ProposalBlockCreated(ProposalBlock),
-
-    ConvergenceBlockCreated(ConvergenceBlock),
-
     ConvergenceBlockCertified(ConvergenceBlock),
 
     QuorumElectionStarted(BlockHeader),
 
-    // NOTE: replaces Event::Farm and pushes txns to the scheduler instead of having it pull them
-    TxnsReadyForProcessing(Vec<TransactionKind>),
-
-    TransactionValidated(Vote),
-
     TransactionsValidated {
         vote: Vote,
         quorum_threshold: FarmerQuorumThreshold,
-    },
-
-    /// `ProposalBlockMineRequestCreated` triggers the mining of a proposal
-    /// block by a farmer node after every `X` seconds. The proposal block
-    /// contains a list of transactions that have been validated and certified
-    /// by the farmer node
-    ProposalBlockMineRequestCreated {
-        ref_hash: RefHash,
-        round: Round,
-        epoch: Epoch,
-        claim: Claim,
-    },
-
-    ConvergenceBlockSignatureRequested(ConvergenceBlock),
-
-    /// `ConvergenceBlockPartialSignatureCreated` is an event that is triggered
-    /// when a node has partially signed a convergence block. The
-    /// `JobResult` parameter contains the result of the partial signing
-    /// process, which includes the partial signature and the public key share
-    /// used to verify it. This event is used to communicate the partial
-    /// signature to other nodes in the network, so that they can aggregate
-    /// it with their own partial signatures to create a complete signature for
-    /// the convergence block,also it adds the partial signature to
-    /// certificate cache
-    ConvergenceBlockPartialSignatureCreated {
-        block_hash: BlockHash,
-        public_key_share: ValidatorPublicKeyShare,
-        partial_signature: Signature,
     },
 
     /// `ConvergenceBlockPrecheckRequested` is a function
@@ -219,24 +141,13 @@ pub enum Event {
         block_header: BlockHeader,
     },
 
-    /// `ConvergenceBlockPeerSignatureRequested` is an event that is used to create an
-    /// aggregated signatures out of  a partial signature shares from peers
-    ConvergenceBlockPeerSignatureRequested {
-        node_id: NodeId,
-        block_hash: BlockHash,
-        public_key_share: PublicKeyShareVec,
-        partial_signature: Signature,
-    },
-
-    Ping(NodeId),
-
     // TODO: refactor all the events below
     // ==========================================================================
     ///
     ///
     /// `UpdateState` is an event that triggers the update of the node's state
     /// to a new block hash. This event is used to update the node's state
-    /// after a last new convergence block has been certified .
+    /// after a last new convergence block has been certified.
     UpdateState(ConvergenceBlock),
 
     /// `ConvergenceBlockPartialSign(JobResult)` is an event that is triggered
@@ -251,40 +162,17 @@ pub enum Event {
     ConvergenceBlockPartialSign(JobStatus),
     ConvergenceBlockPartialSignComplete(ConvergencePartialSig),
 
-    /// `CheckConflictResolution` is an event that triggers the checking of a
-    /// proposed conflict resolution.The event is used to initiate the
-    /// conflict resolution process by checking if the proposed conflict
-    /// resolution is valid. This involves verifying that the proposal
-    /// blocks are valid and that they correctly reference the convergence
-    /// block. If the proposed conflict resolution is valid, the event
-    /// triggers the signing of the convergence block and the creation of a
-    /// certificate to prove its validity.
-    CheckConflictResolution((Vec<ProposalBlock>, Round, Seed, ConvergenceBlock)),
-
     /// `SignConvergenceBlock(ConvergenceBlock)` is an event that triggers the
     /// signing of a convergence block by the node. This is done by sending
     /// a Job to the scheduler
     SignConvergenceBlock(ConvergenceBlock),
 
-    /// `SendPeerConvergenceBlockSign` is an event that triggers the sharing of
-    /// a convergence block partial signature with other peers.
-    SendPeerConvergenceBlockSign(NodeIdx, BlockHash, PublicKeyShareVec, Signature),
-
-    /// `SendBlockCertificate(Certificate)` is an event that triggers the
-    /// sending of a `Certificate` object representing a proof that a block
-    /// has been certified by a quorum  in the network. This event is used
-    /// to communicate the convergence block certification to other nodes in the
-    /// network.
-    SendBlockCertificate(Certificate),
-
     /// `BlockCertificate(Certificate)` is an event that carries a `Certificate`
     /// object representing a proof that a block has been certified by a
     /// quorum. This certificate is then added to convergence block .
     BlockCertificateCreated(Certificate),
-    QuorumMembersReceived(QuorumMembers),
     QuorumFormed,
     HarvesterSignatureReceived(BlockHash, NodeId, Signature),
-    BroadcastQuorumFormed(QuorumData),
     BroadcastCertificate(Certificate),
     BroadcastTransactionVote(Vote),
     BlockAppended(String),

--- a/crates/events/src/event_data.rs
+++ b/crates/events/src/event_data.rs
@@ -2,8 +2,8 @@ use std::net::SocketAddr;
 
 use block::BlockHash;
 use primitives::{
-    ByteVec, FarmerId, FarmerQuorumThreshold, IsTxnValid, KademliaPeerId, NodeId, NodeIdx,
-    NodeType, PublicKey, QuorumKind, RawSignature, Signature, ValidatorPublicKeyShare,
+    ByteVec, FarmerId, FarmerQuorumThreshold, IsTxnValid, KademliaPeerId, NodeId, NodeType,
+    PublicKey, QuorumKind, RawSignature, Signature, ValidatorPublicKeyShare,
 };
 use serde::{Deserialize, Serialize};
 use vrrb_config::QuorumMember;
@@ -61,18 +61,6 @@ pub struct Vote {
 }
 
 pub type SerializedConvergenceBlock = ByteVec;
-
-#[derive(Debug, Deserialize, Serialize, Hash, Clone, PartialEq, Eq)]
-pub struct BlockVote {
-    pub harvester_id: Vec<u8>,
-    pub harvester_node_id: NodeIdx,
-    pub signature: RawSignature,
-    pub convergence_block: SerializedConvergenceBlock,
-    pub quorum_public_key: Vec<u8>,
-    pub quorum_threshold: usize,
-    // May want to serialize this as a vector of bytes
-    pub execution_result: Option<String>,
-}
 
 // `JobResult` is an enum that represents the possible results of a job that is
 /// executed by a scheduler. It has two variants: `Votes` and `CertifiedTxn`.

--- a/crates/node/src/mining_module.rs
+++ b/crates/node/src/mining_module.rs
@@ -92,36 +92,7 @@ impl Handler<EventMessage> for MiningModule {
             //                 });
             //         }
             //     };
-            // },
-            // Event::CheckConflictResolution((proposal_blocks, round, seed, convergence_block)) =>
-            // {     let tmp_proposal_blocks = proposal_blocks.clone();
-            //     let resolved_proposals_set = self
-            //         .miner
-            //         .resolve(&tmp_proposal_blocks, round, seed)
-            //         .iter()
-            //         .cloned()
-            //         .collect::<HashSet<ProposalBlock>>();
-            //
-            //     let proposal_blocks_set = proposal_blocks
-            //         .iter()
-            //         .cloned()
-            //         .collect::<HashSet<ProposalBlock>>();
-            //
-            //     if proposal_blocks_set == resolved_proposals_set {
-            //         if let Err(err) = self
-            //             .events_tx
-            //             .send(EventMessage::new(
-            //                 None,
-            //                 Event::SignConvergenceBlock(convergence_block),
-            //             ))
-            //             .await
-            //         {
-            //             theater::TheaterError::Other(format!(
-            //                 "failed to send EventMessage for Event::SignConvergenceBlock: {err}"
-            //             ));
-            //         };
-            //     }
-            // },
+            // }
             Event::NoOp => {}
             _ => {}
         }

--- a/crates/node/src/state_manager/handler.rs
+++ b/crates/node/src/state_manager/handler.rs
@@ -37,7 +37,7 @@ impl Handler<EventMessage> for StateManager {
         match event.into() {
             Event::Stop => {
                 return Ok(ActorState::Stopped);
-            },
+            }
 
             Event::NewTxnCreated(txn) => {
                 info!("Storing transaction in mempool for validation");
@@ -55,23 +55,7 @@ impl Handler<EventMessage> for StateManager {
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
 
                 info!("Transaction {} sent to mempool", txn_hash);
-
-                // if self.mempool.size_in_kilobytes() >= MEMPOOL_THRESHOLD_SIZE
-                //     && self.cutoff_transaction.is_none()
-                // {
-                //     info!("mempool threshold reached");
-                //     self.cutoff_transaction = Some(txn_hash.clone());
-                //
-                //     let event = Event::MempoolSizeThesholdReached {
-                //         cutoff_transaction: txn_hash,
-                //     };
-                //
-                //     self.events_tx
-                //         .send(event.into())
-                //         .await
-                //         .map_err(|err|
-                // TheaterError::Other(err.to_string()))?; }
-            },
+            }
 
             Event::TxnValidated(txn) => {
                 self.mempool
@@ -81,7 +65,7 @@ impl Handler<EventMessage> for StateManager {
                 self.confirm_txn(txn)
                     .await
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
-            },
+            }
 
             Event::CreateAccountRequested((address, account_bytes)) => {
                 info!(
@@ -95,7 +79,7 @@ impl Handler<EventMessage> for StateManager {
 
                     info!("account {address} created", address = address.to_string());
                 }
-            },
+            }
             Event::AccountUpdateRequested((_address, _account_bytes)) => {
                 //                if let Ok(account) =
                 // decode_from_binary_byte_slice(&account_bytes) {
@@ -103,37 +87,32 @@ impl Handler<EventMessage> for StateManager {
                 // .map_err(|err| TheaterError::Other(err.to_string()))?;
                 //               }
                 todo!()
-            },
+            }
             Event::UpdateState(block) => {
-                
+
                 //if let Err(err) = self.update_state(block.hash) {
                 //    telemetry::error!("error updating state: {}", err);
                 //}
-            },
-            Event::ClaimCreated(_claim) => {},
+            }
+            Event::ClaimCreated(_claim) => {}
             Event::ClaimReceived(claim) => {
                 info!("Storing claim from: {}", claim.address);
-            },
+            }
             Event::BlockReceived(block) => {
                 self.handle_block_received(&mut block)
                     .await
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
-            },
+            }
             Event::BlockCertificateCreated(certificate) => {
                 self.block_certificate_created(certificate)
                     .map_err(|err| TheaterError::Other(err.to_string()))?;
-            },
+            }
             Event::HarvesterPublicKeyReceived(public_key_set) => {
                 self.dag.set_harvester_pubkeys(public_key_set)
-            },
+            }
 
-            Event::TransactionCertificateCreated { txn, .. } => {
-                // TODO: forward arguments
-                let _ = self.handle_transaction_certificate_created(txn);
-            },
-
-            Event::NoOp => {},
-            _ => {},
+            Event::NoOp => {}
+            _ => {}
         }
 
         Ok(ActorState::Running)


### PR DESCRIPTION
Closes #649 
Deprecated events were handled in a separate PR, this cleans up all events that weren't being used as well as commented out code.