### PR TITLE
Bump `jsonrpsee` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,19 +2435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,10 +2772,9 @@ dependencies = [
  "hyper",
  "log",
  "rustls 0.21.10",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3228,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.16.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367a292944c07385839818bb71c8d76611138e2dedb0677d035b8da21d29c78b"
+checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -3238,105 +3230,106 @@ dependencies = [
  "jsonrpsee-server",
  "jsonrpsee-types",
  "jsonrpsee-ws-client",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.16.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b3815d9f5d5de348e5f162b316dc9cdf4548305ebb15b4eb9328e66cf27d7a"
+checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
 dependencies = [
  "futures-util",
  "http",
  "jsonrpsee-core",
- "jsonrpsee-types",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "url",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.16.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5dde66c53d6dcdc8caea1874a45632ec0fcf5b437789f1e45766a1512ce803"
+checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.4",
- "async-lock 2.8.0",
  "async-trait",
  "beef",
- "futures-channel",
  "futures-timer",
  "futures-util",
- "globset",
  "hyper",
  "jsonrpsee-types",
  "parking_lot",
+ "pin-project",
  "rand 0.8.5",
  "rustc-hash",
  "serde",
  "serde_json",
- "soketto",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.16.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5f9fabdd5d79344728521bb65e3106b49ec405a78b66fbff073b72b389fa43"
+checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
 dependencies = [
  "async-trait",
  "hyper",
  "hyper-rustls",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tower",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.16.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e8ab85614a08792b9bff6c8feee23be78c98d0182d4c622c05256ab553892a"
+checksum = "7d0bb047e79a143b32ea03974a6bf59b62c2a4c5f5d42a381c907a8bbb3f75c0"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote 1.0.35",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.16.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4d945a6008c9b03db3354fb3c83ee02d2faa9f2e755ec1dfb69c3551b8f4ba"
+checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
 dependencies = [
- "futures-channel",
  "futures-util",
  "http",
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "pin-project",
+ "route-recognizer",
  "serde",
  "serde_json",
  "soketto",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3346,28 +3339,28 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.16.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245ba8e5aa633dd1c1e4fae72bce06e71f42d34c14a2767c6b4d173b57bee5e5"
+checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
 dependencies = [
  "anyhow",
  "beef",
  "serde",
  "serde_json",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.16.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1b3975ed5d73f456478681a417128597acd6a2487855fdb7b4a3d4d195bf5e"
+checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "url",
 ]
 
 [[package]]
@@ -4232,7 +4225,7 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote 1.0.35",
  "syn 1.0.109",
@@ -4644,12 +4637,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -5527,6 +5528,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5645,8 +5652,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.7",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.7",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5657,6 +5678,19 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -5680,12 +5714,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.7",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring 0.17.7",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -6806,6 +6867,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6814,6 +6886,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6868,9 +6941,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -6897,6 +6970,17 @@ dependencies = [
  "indexmap 2.2.2",
  "serde",
  "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.2",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ ethereum-types = "0.13"
 hex = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 indexmap = "1.9"
-jsonrpsee = { version = "0.16", features = [
+jsonrpsee = { version = "0.22.5", features = [
   "macros",
   "client-core",
   "server-core",

--- a/crates/internal_rpc/src/api.rs
+++ b/crates/internal_rpc/src/api.rs
@@ -1,11 +1,10 @@
 use crate::job_queue::job::{ServiceJobStatusResponse, ServiceJobType};
+use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use platform::services::ServiceStatusResponse;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::str::FromStr;
-
-pub(crate) type RpcResult<T> = Result<T, jsonrpsee::core::Error>;
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub enum IPFSDataType {

--- a/crates/internal_rpc/src/client.rs
+++ b/crates/internal_rpc/src/client.rs
@@ -1,6 +1,7 @@
-use crate::api::RpcResult;
 use crate::server::MAX_RESPONSE_SIZE;
-use jsonrpsee::core::client::Client;
+use jsonrpsee::core::{client::Client, RpcResult};
+use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
+use jsonrpsee::types::ErrorObject as RpseeError;
 use jsonrpsee::ws_client::WsClientBuilder;
 use std::net::SocketAddr;
 
@@ -16,18 +17,20 @@ impl InternalRpcClient {
     /// The URL to the server MUST include the port.
     pub async fn new(socket: SocketAddr) -> RpcResult<Self> {
         let client = WsClientBuilder::default()
-            .max_request_body_size(MAX_RESPONSE_SIZE)
+            .max_request_size(MAX_RESPONSE_SIZE)
             .build(format!("ws://{socket}"))
-            .await?;
+            .await
+            .unwrap();
 
         if client.is_connected() {
             println!("connection to server established");
             Ok(InternalRpcClient(client))
         } else {
-            Err(jsonrpsee::core::Error::Custom(format!(
-                "failed to establish connection to server at {}",
-                socket
-            )))
+            Err(RpseeError::owned(
+                INTERNAL_ERROR_CODE,
+                format!("failed to establish connection to server at {socket}"),
+                None::<()>,
+            ))?
         }
     }
     pub fn is_connected(&self) -> bool {

--- a/crates/internal_rpc/src/client.rs
+++ b/crates/internal_rpc/src/client.rs
@@ -20,7 +20,13 @@ impl InternalRpcClient {
             .max_request_size(MAX_RESPONSE_SIZE)
             .build(format!("ws://{socket}"))
             .await
-            .unwrap();
+            .map_err(|e| {
+                RpseeError::owned(
+                    INTERNAL_ERROR_CODE,
+                    format!("failed to build client: {e}"),
+                    None::<()>,
+                )
+            })?;
 
         if client.is_connected() {
             println!("connection to server established");

--- a/crates/internal_rpc/src/job_queue/job.rs
+++ b/crates/internal_rpc/src/job_queue/job.rs
@@ -164,7 +164,7 @@ pub enum ServiceJobState {
 
 /// The reponse sent from the server when requested by a client
 /// about the state of a job.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ServiceJobStatusResponse {
     pub(crate) status: ServiceJobState,
     pub(crate) uptime: u64,

--- a/crates/platform/src/services.rs
+++ b/crates/platform/src/services.rs
@@ -78,7 +78,7 @@ impl std::fmt::Display for VersionNumber {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ServiceStatusResponse {
     /// Type of service (see above)
     pub service_type: ServiceType,

--- a/crates/vrrb_rpc/src/lib.rs
+++ b/crates/vrrb_rpc/src/lib.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use jsonrpsee::core::Error as RpseeError;
+use jsonrpsee::types::ErrorObjectOwned as RpseeError;
 
 pub mod http;
 pub mod rpc;

--- a/crates/vrrb_rpc/src/rpc/api.rs
+++ b/crates/vrrb_rpc/src/rpc/api.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use block::block::Block;
 use block::ClaimHash;
-use jsonrpsee::{core::Error as RpseeError, proc_macros::rpc};
+use jsonrpsee::{proc_macros::rpc, types::ErrorObjectOwned as RpseeError};
 use primitives::{Address, NodeType, Round};
 use secp256k1::PublicKey;
 use serde::{Deserialize, Serialize};

--- a/crates/vrrb_rpc/src/rpc/server.rs
+++ b/crates/vrrb_rpc/src/rpc/server.rs
@@ -1,9 +1,8 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
 use events::{EventPublisher, DEFAULT_BUFFER};
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use mempool::{LeftRightMempool, MempoolReadHandleFactory};
 use primitives::NodeType;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use storage::vrrbdb::{VrrbDb, VrrbDbConfig, VrrbDbReadHandle};
 use tokio::sync::mpsc::channel;
 
@@ -33,7 +32,7 @@ impl JsonRpcServer {
         };
 
         let addr = server.local_addr()?;
-        let handle = server.start(server_impl.into_rpc())?;
+        let handle = server.start(server_impl.into_rpc());
 
         // TODO: refactor example out of here
         // In this example we don't care about doing shutdown so let's it run forever.

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -167,7 +167,10 @@ impl RpcApiServer for RpcServerImpl {
         self.events_tx
             .send(event.clone().into())
             .await
-            .map_err(|e| RpseeError::owned(INTERNAL_ERROR_CODE, e.to_string(), None::<()>))?;
+            .map_err(|e| {
+                error!("could not create account: {e}");
+                RpseeError::owned(INTERNAL_ERROR_CODE, e.to_string(), None::<()>)
+            })?;
 
         telemetry::info!("requested account creation for address: {}", address);
 

--- a/crates/vrrb_rpc/src/rpc/server_impl.rs
+++ b/crates/vrrb_rpc/src/rpc/server_impl.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use block::block::Block;
 use block::ClaimHash;
 use events::{Event, EventPublisher};
-use jsonrpsee::core::Error as RpseeError;
+use jsonrpsee::types::{
+    error::{INTERNAL_ERROR_CODE, PARSE_ERROR_CODE},
+    ErrorObjectOwned as RpseeError,
+};
 use mempool::MempoolReadHandleFactory;
 use primitives::{Address, NodeType, Round};
 use secp256k1::{Message, SecretKey};
@@ -67,9 +70,12 @@ impl RpcApiServer for RpcServerImpl {
 
         debug!("{:?}", event);
 
-        self.events_tx.send(event.into()).await.map_err(|err| {
-            error!("could not queue transaction to mempool: {err}");
-            RpseeError::Custom(err.to_string())
+        self.events_tx.send(event.into()).await.map_err(|e| {
+            RpseeError::owned(
+                INTERNAL_ERROR_CODE,
+                format!("could not queue transaction to mempool: {e}"),
+                None::<()>,
+            )
         })?;
 
         Ok(RpcTransactionRecord::from(txn))
@@ -84,7 +90,13 @@ impl RpcApiServer for RpcServerImpl {
 
         let parsed_digest = transaction_digest
             .parse::<TransactionDigest>()
-            .map_err(|_err| RpseeError::Custom("unable to parse transaction digest".to_string()))?;
+            .map_err(|_e| {
+                RpseeError::owned(
+                    PARSE_ERROR_CODE,
+                    "unable to parse transaction digest".to_string(),
+                    None::<()>,
+                )
+            })?;
 
         let values = self
             .vrrbdb_read_handle
@@ -101,7 +113,15 @@ impl RpcApiServer for RpcServerImpl {
                 let txn_record = RpcTransactionRecord::from(txn.clone());
                 Ok(txn_record)
             }
-            None => return Err(RpseeError::Custom("unable to find transaction".to_string())),
+            None => {
+                return Err({
+                    RpseeError::owned(
+                        INTERNAL_ERROR_CODE,
+                        "unable to find transaction".to_string(),
+                        None::<()>,
+                    )
+                })
+            }
         }
     }
 
@@ -137,8 +157,8 @@ impl RpcApiServer for RpcServerImpl {
     }
 
     async fn create_account(&self, address: Address, account: Account) -> Result<(), RpseeError> {
-        let account_bytes =
-            encode_to_binary(&account).map_err(|err| RpseeError::Custom(err.to_string()))?;
+        let account_bytes = encode_to_binary(&account)
+            .map_err(|e| RpseeError::owned(INTERNAL_ERROR_CODE, e.to_string(), None::<()>))?;
 
         let event = Event::CreateAccountRequested((address.clone(), account_bytes));
 
@@ -147,10 +167,7 @@ impl RpcApiServer for RpcServerImpl {
         self.events_tx
             .send(event.clone().into())
             .await
-            .map_err(|err| {
-                error!("could not create account: {err}");
-                RpseeError::Custom(err.to_string())
-            })?;
+            .map_err(|e| RpseeError::owned(INTERNAL_ERROR_CODE, e.to_string(), None::<()>))?;
 
         telemetry::info!("requested account creation for address: {}", address);
 
@@ -160,17 +177,21 @@ impl RpcApiServer for RpcServerImpl {
     async fn update_account(&self, account: Account) -> Result<(), RpseeError> {
         debug!("Received an updateAccount RPC request");
 
-        let account_bytes =
-            encode_to_binary(&account).map_err(|err| RpseeError::Custom(err.to_string()))?;
+        let account_bytes = encode_to_binary(&account)
+            .map_err(|e| RpseeError::owned(INTERNAL_ERROR_CODE, e.to_string(), None::<()>))?;
 
-        let addr =
-            Address::from_str(account.hash()).map_err(|err| RpseeError::Custom(err.to_string()))?;
+        let addr = Address::from_str(account.hash())
+            .map_err(|e| RpseeError::owned(INTERNAL_ERROR_CODE, e.to_string(), None::<()>))?;
 
         let event = Event::AccountUpdateRequested((addr, account_bytes));
 
-        self.events_tx.send(event.into()).await.map_err(|err| {
-            error!("could not update account: {err}");
-            RpseeError::Custom(err.to_string())
+        self.events_tx.send(event.into()).await.map_err(|e| {
+            error!("could not update account: {e}");
+            RpseeError::owned(
+                INTERNAL_ERROR_CODE,
+                format!("could not update account: {e}"),
+                None::<()>,
+            )
         })?;
 
         Ok(())
@@ -179,10 +200,13 @@ impl RpcApiServer for RpcServerImpl {
     async fn get_account(&self, address: Address) -> Result<Account, RpseeError> {
         telemetry::info!("retrieving account {address}");
 
-        let values = self
-            .vrrbdb_read_handle
-            .state_store_values()
-            .map_err(|err| RpseeError::Custom(format!("failed to read values: {err}")))?;
+        let values = self.vrrbdb_read_handle.state_store_values().map_err(|e| {
+            RpseeError::owned(
+                INTERNAL_ERROR_CODE,
+                format!("failed to read values: {e}"),
+                None::<()>,
+            )
+        })?;
 
         let value = values.get(&address);
 
@@ -190,7 +214,15 @@ impl RpcApiServer for RpcServerImpl {
 
         match value {
             Some(account) => return Ok(account.to_owned()),
-            None => return Err(RpseeError::Custom("unable to find account".to_string())),
+            None => {
+                return Err({
+                    RpseeError::owned(
+                        INTERNAL_ERROR_CODE,
+                        format!("unable to find account: {value:?}"),
+                        None::<()>,
+                    )
+                })
+            }
         }
     }
 
@@ -221,7 +253,15 @@ impl RpcApiServer for RpcServerImpl {
 
         let secret_key = match secret_key_result {
             Ok(secret_key) => secret_key,
-            Err(_) => return Err(RpseeError::Custom("unable to parse secret_key".to_string())),
+            Err(_) => {
+                return Err({
+                    RpseeError::owned(
+                        PARSE_ERROR_CODE,
+                        "unable to parse secret_key".to_string(),
+                        None::<()>,
+                    )
+                })
+            }
         };
 
         Ok(secret_key.sign_ecdsa(msg).to_string())
@@ -257,10 +297,13 @@ impl RpcApiServer for RpcServerImpl {
     }
 
     async fn get_claims_by_account_id(&self, address: Address) -> Result<Claims, RpseeError> {
-        let claims = self
-            .vrrbdb_read_handle
-            .claim_store_values()
-            .map_err(|err| RpseeError::Custom(format!("Failed to read values: {err}")))?;
+        let claims = self.vrrbdb_read_handle.claim_store_values().map_err(|e| {
+            RpseeError::owned(
+                INTERNAL_ERROR_CODE,
+                format!("Failed to read values: {e}"),
+                None::<()>,
+            )
+        })?;
 
         let claims = claims
             .values()
@@ -272,10 +315,13 @@ impl RpcApiServer for RpcServerImpl {
     }
 
     async fn get_claim_hashes(&self) -> Result<Vec<ClaimHash>, RpseeError> {
-        let claims = self
-            .vrrbdb_read_handle
-            .claim_store_values()
-            .map_err(|err| RpseeError::Custom(format!("Failed to read values: {err}")))?;
+        let claims = self.vrrbdb_read_handle.claim_store_values().map_err(|e| {
+            RpseeError::owned(
+                INTERNAL_ERROR_CODE,
+                format!("Failed to read values: {e}"),
+                None::<()>,
+            )
+        })?;
 
         let claim_hashes = claims.values().map(|claim| claim.hash).collect();
 
@@ -283,10 +329,13 @@ impl RpcApiServer for RpcServerImpl {
     }
 
     async fn get_claims(&self, claim_hashes: Vec<ClaimHash>) -> Result<Claims, RpseeError> {
-        let claims = self
-            .vrrbdb_read_handle
-            .claim_store_values()
-            .map_err(|err| RpseeError::Custom(format!("Failed to read values: {err}")))?;
+        let claims = self.vrrbdb_read_handle.claim_store_values().map_err(|e| {
+            RpseeError::owned(
+                INTERNAL_ERROR_CODE,
+                format!("Failed to read values: {e}"),
+                None::<()>,
+            )
+        })?;
 
         let claims = claims
             .values()


### PR DESCRIPTION
Closes #797 
Bumps jsonrpsee dep to `0.22.5` and handles API changes.
